### PR TITLE
Add TrainingPeaks MCP with new Fitness & Sports category

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[kukapay/token-minter-mcp](https://github.com/kukapay/token-minter-mcp)** [![GitHub stars](https://img.shields.io/github/stars/kukapay/token-minter-mcp?style=social)](https://github.com/kukapay/token-minter-mcp): Allows AI agents to mint ERC-20 tokens.
 -   **[kukapay/thegraph-mcp](https://github.com/kukapay/thegraph-mcp)** [![GitHub stars](https://img.shields.io/github/stars/kukapay/thegraph-mcp?style=social)](https://github.com/kukapay/thegraph-mcp): Provides indexed blockchain data from The Graph to AI agents.
 
+### 🏃 Fitness & Sports
+
+-   **[JamsusMaximus/trainingpeaks-mcp](https://github.com/JamsusMaximus/trainingpeaks-mcp)** [![GitHub stars](https://img.shields.io/github/stars/JamsusMaximus/trainingpeaks-mcp?style=social)](https://github.com/JamsusMaximus/trainingpeaks-mcp): Accesses TrainingPeaks training data including fitness metrics (CTL/ATL/TSB), workout history, and power/pace personal records for endurance athletes.
+
 ### 🎮 Gaming
 
 -   **[Coding-Solo/godot-mcp](https://github.com/Coding-Solo/godot-mcp)** [![GitHub stars](https://img.shields.io/github/stars/Coding-Solo/godot-mcp?style=social)](https://github.com/Coding-Solo/godot-mcp): Interacts with the Godot game engine for editing, running, and managing scenes.


### PR DESCRIPTION
## Summary

Adds a new **Fitness & Sports** category and includes [TrainingPeaks MCP](https://github.com/JamsusMaximus/trainingpeaks-mcp) as the first entry.

**TrainingPeaks MCP** enables AI assistants to analyze endurance athlete training data:
- Training data and workout history
- Fitness metrics: CTL (Chronic Training Load), ATL (Acute Training Load), TSB (Training Stress Balance)
- Historical fitness data for any date range
- Power and pace personal records across all-time training history

This creates a dedicated home for fitness and sports analytics servers.

## Links

- Repository: https://github.com/JamsusMaximus/trainingpeaks-mcp
- MIT licensed
- Python-based with full MCP 1.0 support