### PR TITLE
Add Rippling MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[sawa-zen/vrchat-mcp](https://github.com/sawa-zen/vrchat-mcp)** [![GitHub stars](https://img.shields.io/github/stars/sawa-zen/vrchat-mcp?style=social)](https://github.com/sawa-zen/vrchat-mcp): Interacts with the VRChat API to retrieve user, world, and avatar information.
 -   **[arpitbatra123/mcp-googletasks](https://github.com/arpitbatra123/mcp-googletasks)** [![GitHub stars](https://img.shields.io/github/stars/arpitbatra123/mcp-googletasks?style=social)](https://github.com/arpitbatra123/mcp-googletasks): Interfaces with the Google Tasks API for task management.
 -   **[Eclipse-XV/twitch-mcp](https://github.com/Eclipse-XV/twitch-mcp)** [![GitHub stars](https://img.shields.io/github/stars/Eclipse-XV/twitch-mcp?style=social)](https://github.com/Eclipse-XV/twitch-mcp): Allows Twitch streamers to automate channel point predictions, trigger stream events, and extend interactive chat functionality.
+-   **[bifrost-mcp/rippling-mcp](https://github.com/bifrost-mcp/rippling-mcp)** [![GitHub stars](https://img.shields.io/github/stars/bifrost-mcp/rippling-mcp?style=social)](https://github.com/bifrost-mcp/rippling-mcp): Integrates with Rippling HR/IT/Finance platform for managing employees, departments, leave requests, and company operations through 18 tools.
 
 ### 👤 Customer Data Platforms
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[sawa-zen/vrchat-mcp](https://github.com/sawa-zen/vrchat-mcp)** [![GitHub stars](https://img.shields.io/github/stars/sawa-zen/vrchat-mcp?style=social)](https://github.com/sawa-zen/vrchat-mcp): Interacts with the VRChat API to retrieve user, world, and avatar information.
 -   **[arpitbatra123/mcp-googletasks](https://github.com/arpitbatra123/mcp-googletasks)** [![GitHub stars](https://img.shields.io/github/stars/arpitbatra123/mcp-googletasks?style=social)](https://github.com/arpitbatra123/mcp-googletasks): Interfaces with the Google Tasks API for task management.
 -   **[Eclipse-XV/twitch-mcp](https://github.com/Eclipse-XV/twitch-mcp)** [![GitHub stars](https://img.shields.io/github/stars/Eclipse-XV/twitch-mcp?style=social)](https://github.com/Eclipse-XV/twitch-mcp): Allows Twitch streamers to automate channel point predictions, trigger stream events, and extend interactive chat functionality.
--   **[bifrost-mcp/rippling-mcp](https://github.com/bifrost-mcp/rippling-mcp)** [![GitHub stars](https://img.shields.io/github/stars/bifrost-mcp/rippling-mcp?style=social)](https://github.com/bifrost-mcp/rippling-mcp): Integrates with Rippling HR/IT/Finance platform for managing employees, departments, leave requests, and company operations through 18 tools.
+-   **[@bifrost-mcp/rippling-mcp](https://github.com/bifrost-mcp/rippling-mcp)** [![GitHub stars](https://img.shields.io/github/stars/bifrost-mcp/rippling-mcp?style=social)](https://github.com/bifrost-mcp/rippling-mcp): Integrates with Rippling HR/IT/Finance platform for managing employees, departments, payroll, benefits, and company operations through 18 tools.
 
 ### 👤 Customer Data Platforms
 


### PR DESCRIPTION
Adds [Rippling MCP](https://github.com/bifrost-mcp/rippling-mcp) — an MCP server for the Rippling HR/IT/Finance platform with 18 tools for managing employees, departments, leave requests, groups, and company operations.

- npm: `rippling-mcp-server`
- MIT licensed
- TypeScript