### PR TITLE
Add Taskade MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[sawa-zen/vrchat-mcp](https://github.com/sawa-zen/vrchat-mcp)** [![GitHub stars](https://img.shields.io/github/stars/sawa-zen/vrchat-mcp?style=social)](https://github.com/sawa-zen/vrchat-mcp): Interacts with the VRChat API to retrieve user, world, and avatar information.
 -   **[arpitbatra123/mcp-googletasks](https://github.com/arpitbatra123/mcp-googletasks)** [![GitHub stars](https://img.shields.io/github/stars/arpitbatra123/mcp-googletasks?style=social)](https://github.com/arpitbatra123/mcp-googletasks): Interfaces with the Google Tasks API for task management.
 -   **[Eclipse-XV/twitch-mcp](https://github.com/Eclipse-XV/twitch-mcp)** [![GitHub stars](https://img.shields.io/github/stars/Eclipse-XV/twitch-mcp?style=social)](https://github.com/Eclipse-XV/twitch-mcp): Allows Twitch streamers to automate channel point predictions, trigger stream events, and extend interactive chat functionality.
+-   **[taskade/mcp](https://github.com/taskade/mcp)** [![GitHub stars](https://img.shields.io/github/stars/taskade/mcp?style=social)](https://github.com/taskade/mcp): Official Taskade MCP server with 62+ tools for managing workspaces, projects, tasks, AI agents, templates, and media. Works with Claude, Cursor, Windsurf, and all MCP clients.
 
 ### 👤 Customer Data Platforms
 


### PR DESCRIPTION
## Add Taskade MCP Server

Adds [Taskade MCP Server](https://github.com/taskade/mcp) to the Communication section.

**Taskade MCP Server** (`@taskade/mcp-server`) is the official MCP server for [Taskade](https://www.taskade.com/) with 62+ tools for managing workspaces, projects, tasks, AI agents, templates, and media. It works with Claude, Cursor, Windsurf, VS Code, and all MCP clients.

- GitHub: https://github.com/taskade/mcp
- npm: `@taskade/mcp-server`
- License: MIT
- Language: TypeScript