### PR TITLE
Add Taskade MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[sawa-zen/vrchat-mcp](https://github.com/sawa-zen/vrchat-mcp)** [![GitHub stars](https://img.shields.io/github/stars/sawa-zen/vrchat-mcp?style=social)](https://github.com/sawa-zen/vrchat-mcp): Interacts with the VRChat API to retrieve user, world, and avatar information.
 -   **[arpitbatra123/mcp-googletasks](https://github.com/arpitbatra123/mcp-googletasks)** [![GitHub stars](https://img.shields.io/github/stars/arpitbatra123/mcp-googletasks?style=social)](https://github.com/arpitbatra123/mcp-googletasks): Interfaces with the Google Tasks API for task management.
 -   **[Eclipse-XV/twitch-mcp](https://github.com/Eclipse-XV/twitch-mcp)** [![GitHub stars](https://img.shields.io/github/stars/Eclipse-XV/twitch-mcp?style=social)](https://github.com/Eclipse-XV/twitch-mcp): Allows Twitch streamers to automate channel point predictions, trigger stream events, and extend interactive chat functionality.
+-   **[@taskade/mcp](https://github.com/taskade/mcp)** [![GitHub stars](https://img.shields.io/github/stars/taskade/mcp?style=social)](https://github.com/taskade/mcp): Official Taskade MCP server with 50+ tools for managing workspaces, projects, tasks, custom AI agents, and workflow automations. Includes OpenAPI-to-MCP codegen.
 
 ### 👤 Customer Data Platforms
 


### PR DESCRIPTION
## Summary

- Adds **[@taskade/mcp](https://github.com/taskade/mcp)** to the Communication section
- Official Taskade MCP server with 50+ tools for managing workspaces, projects, tasks, custom AI agents, and workflow automations
- Includes OpenAPI-to-MCP codegen
- Install: `npx @taskade/mcp-server`
- npm: [@taskade/mcp-server](https://www.npmjs.com/package/@taskade/mcp-server)
- Website: [taskade.com](https://taskade.com)

Taskade is a YC S19 productivity platform for teams.