### PR TITLE
Add Speech AI MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Note that this list is continuously updating and improving. Please star this rep
 ### 🎨 Art & Culture
 
 -   **[burningion/video-editing-mcp](https://github.com/burningion/video-editing-mcp)** [![GitHub stars](https://img.shields.io/github/stars/burningion/video-editing-mcp?style=social)](https://github.com/burningion/video-editing-mcp): Enables AI-driven video editing, analysis, and search within a video collection.
+-   **[fasuizu-br/speech-ai-examples](https://github.com/fasuizu-br/speech-ai-examples)** [![GitHub stars](https://img.shields.io/github/stars/fasuizu-br/speech-ai-examples?style=social)](https://github.com/fasuizu-br/speech-ai-examples): Speech AI MCP server with pronunciation assessment (phoneme-level scoring, 17MB model, <300ms), text-to-speech, and speech-to-text. 8 tools for language learning, accessibility, and voice applications.
 -   **[r-huijts/rijksmuseum-mcp](https://github.com/r-huijts/rijksmuseum-mcp)** [![GitHub stars](https://img.shields.io/github/stars/r-huijts/rijksmuseum-mcp?style=social)](https://github.com/r-huijts/rijksmuseum-mcp): Connects to the Rijksmuseum API for accessing art collections and details.
 -   **[yuna0x0/anilist-mcp](https://github.com/yuna0x0/anilist-mcp)** [![GitHub stars](https://img.shields.io/github/stars/yuna0x0/anilist-mcp?style=social)](https://github.com/yuna0x0/anilist-mcp): Provides information on anime and manga through integration with the AniList API.
 


### PR DESCRIPTION
## Summary

Adds [fasuizu-br/speech-ai-examples](https://github.com/fasuizu-br/speech-ai-examples) to the **Art & Culture** section (media/audio related).

Speech AI is an MCP server providing:
- **Pronunciation assessment** with phoneme-level scoring (17MB model, <300ms latency)
- **Text-to-speech** synthesis
- **Speech-to-text** transcription
- 8 MCP tools for language learning, accessibility, and voice applications

## Checklist
- [x] Entry follows the existing format with GitHub stars badge
- [x] Added in alphabetical order
- [x] Link points to a public GitHub repository