### PR TITLE
Add IndieStack MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[andybrandt/mcp-simple-arxiv](https://github.com/andybrandt/mcp-simple-arxiv)** [![GitHub stars](https://img.shields.io/github/stars/andybrandt/mcp-simple-arxiv?style=social)](https://github.com/andybrandt/mcp-simple-arxiv): Allows searching and reading papers from arXiv.
 -   **[andybrandt/mcp-simple-pubmed](https://github.com/andybrandt/mcp-simple-pubmed)** [![GitHub stars](https://img.shields.io/github/stars/andybrandt/mcp-simple-pubmed?style=social)](https://github.com/andybrandt/mcp-simple-pubmed): Allows searching and reading papers from PubMed.
 -   **[shopsavvy/shopsavvy-mcp-server](https://github.com/shopsavvy/shopsavvy-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/shopsavvy/shopsavvy-mcp-server?style=social)](https://github.com/shopsavvy/shopsavvy-mcp-server): Complete product and pricing data solution for AI assistants. Search for products by barcode/ASIN/URL, access detailed product metadata, access comprehensive pricing data from thousands of retailers, view and track price history, and more. Published as `@shopsavvy/mcp-server`.
+-   **[Pattyboi101/indiestack](https://github.com/Pattyboi101/indiestack)** [![GitHub stars](https://img.shields.io/github/stars/Pattyboi101/indiestack?style=social)](https://github.com/Pattyboi101/indiestack): Search 130+ indie SaaS tools from your AI coding assistant. Install via `pip install indiestack`.
 
 ### 🛠️ Utilities
 


### PR DESCRIPTION
## Summary
- Adds [IndieStack](https://github.com/Pattyboi101/indiestack) to the Search section
- IndieStack is an MCP server that lets AI coding assistants search 130+ indie SaaS tools
- Installable via `pip install indiestack`

## Details
- **Name**: IndieStack
- **GitHub**: https://github.com/Pattyboi101/indiestack
- **Install**: `pip install indiestack`
- **Category**: Search (enables searching a curated directory of indie SaaS tools)