### PR TITLE
Add preflight MCP server to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[Rootly-AI-Labs/Rootly-MCP-server](https://github.com/Rootly-AI-Labs/Rootly-MCP-server)** [![GitHub stars](https://img.shields.io/github/stars/Rootly-AI-Labs/Rootly-MCP-server?style=social)](https://github.com/Rootly-AI-Labs/Rootly-MCP-server): Integrates with the Rootly incident management platform.
 -   **[YuChenSSR/mindmap-mcp-server](https://github.com/YuChenSSR/mindmap-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/YuChenSSR/mindmap-mcp-server?style=social)](https://github.com/YuChenSSR/mindmap-mcp-server): Generates interactive mindmaps.
 -   **[SDGLBL/mcp-claude-code](https://github.com/SDGLBL/mcp-claude-code)** [![GitHub stars](https://img.shields.io/github/stars/SDGLBL/mcp-claude-code?style=social)](https://github.com/SDGLBL/mcp-claude-code): Implements Claude Code capabilities using MCP, enabling code understanding and project analysis.
+-   **[preflight-dev/preflight](https://github.com/preflight-dev/preflight)** [![GitHub stars](https://img.shields.io/github/stars/preflight-dev/preflight?style=social)](https://github.com/preflight-dev/preflight): 24-tool MCP server for Claude Code that catches vague prompts before execution, provides 12-category scoring, cross-service contract awareness, correction pattern learning, and semantic session history search via LanceDB.
 
 ### 🧮 Data Science Tools
 


### PR DESCRIPTION
Adding [preflight](https://github.com/preflight-dev/preflight) — a 24-tool MCP server for Claude Code that catches ambiguous prompts before execution, provides 12-category scoring, cross-service contract awareness, correction pattern learning, and semantic session history search via LanceDB vectors.

- **npm:** `npx preflight-dev`
- **Category:** Developer Tools
- **Language:** TypeScript