### PR TITLE
docs: add Nutrient DWS MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[cyberchitta/llm-context.py](https://github.com/cyberchitta/llm-context.py)** [![GitHub stars](https://img.shields.io/github/stars/cyberchitta/llm-context.py?style=social)](https://github.com/cyberchitta/llm-context.py): Shares code context with LLMs via MCP or clipboard.
 -   **[quarkiverse/quarkus-mcp-filesystem](https://github.com/quarkiverse/quarkus-mcp-servers/tree/main/filesystem)** [![GitHub stars](https://img.shields.io/github/stars/quarkiverse/quarkus-mcp-servers?style=social)](https://github.com/quarkiverse/quarkus-mcp-servers): Provides file system browsing and editing (part of Quarkus MCP Servers, Java implementation).
 -   **[Xuanwo/mcp-server-opendal](https://github.com/Xuanwo/mcp-server-opendal)** [![GitHub stars](https://img.shields.io/github/stars/Xuanwo/mcp-server-opendal?style=social)](https://github.com/Xuanwo/mcp-server-opendal): Accesses various storage services via Apache OpenDAL.
+-   **[PSPDFKit/nutrient-dws-mcp-server](https://github.com/PSPDFKit/nutrient-dws-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/PSPDFKit/nutrient-dws-mcp-server?style=social)](https://github.com/PSPDFKit/nutrient-dws-mcp-server): MCP server for Nutrient Document Web Services API for conversion, merge, redact, sign, OCR, watermark, and extraction workflows.
 
 ### 💰 Finance & Fintech
 


### PR DESCRIPTION
Adds **Nutrient DWS MCP Server** to the **File Systems** section.

- Repo: https://github.com/PSPDFKit/nutrient-dws-mcp-server
- Capability summary: MCP tools for document processing workflows (convert, merge, redact, sign, OCR, watermark, extract).

If you'd like, I can also submit a follow-up entry for nutrient-document-engine-mcp-server.
