### PR TITLE
Add Resolve MCP Server to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[pydantic/logfire-mcp](https://github.com/pydantic/logfire-mcp)** [![GitHub stars](https://img.shields.io/github/stars/pydantic/logfire-mcp?style=social)](https://github.com/pydantic/logfire-mcp): Accesses OpenTelemetry traces and metrics through Logfire.
 -   **[seekrays/mcp-monitor](https://github.com/seekrays/mcp-monitor)** [![GitHub stars](https://img.shields.io/github/stars/seekrays/mcp-monitor?style=social)](https://github.com/seekrays/mcp-monitor): Provides system monitoring via MCP, exposing various metrics.
 -   **[hyperb1iss/lucidity-mcp](https://github.com/hyperb1iss/lucidity-mcp)** [![GitHub stars](https://img.shields.io/github/stars/hyperb1iss/lucidity-mcp?style=social)](https://github.com/hyperb1iss/lucidity-mcp): Provides intelligent, prompt-based analysis of AI-generated code across multiple dimensions.
+-   **[unitedideas/resolve-mcp](https://github.com/unitedideas/resolve-mcp)** [![GitHub stars](https://img.shields.io/github/stars/unitedideas/resolve-mcp?style=social)](https://github.com/unitedideas/resolve-mcp): Structured error recovery for AI agents. Returns resolution playbooks with backoff schedules, retry strategies, and recovery steps for 20+ services including OpenAI, Anthropic, Stripe, AWS, and Postgres.
 
 ### 🔎 Search
 


### PR DESCRIPTION
Adds [Resolve MCP Server](https://github.com/unitedideas/resolve-mcp) to the Monitoring section.

Structured error recovery for AI agents. Returns resolution playbooks (backoff schedules, retry strategies, recovery steps) for 20+ services including OpenAI, Anthropic, Stripe, AWS, Postgres, and more.

Free tier: 500 requests/month.