### PR TITLE
Add signbee/mcp — document signing MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[@j4c0bs/mcp-server-sql-analyzer](https://github.com/j4c0bs/mcp-server-sql-analyzer)** [![GitHub stars](https://img.shields.io/github/stars/j4c0bs/mcp-server-sql-analyzer?style=social)](https://github.com/j4c0bs/mcp-server-sql-analyzer): Provides SQL analysis, linting, and dialect conversion using SQLGlot.
 -   **[0xshellming/mcp-summarizer](https://github.com/0xshellming/mcp-summarizer)** [![GitHub stars](https://img.shields.io/github/stars/0xshellming/mcp-summarizer?style=social)](https://github.com/0xshellming/mcp-summarizer): Provides AI summarization for multiple content types.
 -   **[SecretiveShell/MCP-timeserver](https://github.com/SecretiveShell/MCP-timeserver)** [![GitHub stars](https://img.shields.io/github/stars/SecretiveShell/MCP-timeserver?style=social)](https://github.com/SecretiveShell/MCP-timeserver): Provides the current time in any timezone.
+-   **[signbee/mcp](https://github.com/signbee/mcp)** [![GitHub stars](https://img.shields.io/github/stars/signbee/mcp?style=social)](https://github.com/signbee/mcp): Document signing for AI agents — send markdown or PDF for two-party e-signing with SHA-256 certified delivery.
 
 
 ## Star History


### PR DESCRIPTION
Adds signbee/mcp to the Utilities section. Document signing for AI agents — send markdown or PDF for two-party e-signing with SHA-256 certified delivery. npm: signbee-mcp