### PR TITLE
Add Lightning Wallet MCP to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[OzorOwn/defi-mcp](https://github.com/OzorOwn/defi-mcp)** [![GitHub stars](https://img.shields.io/github/stars/OzorOwn/defi-mcp?style=social)](https://github.com/OzorOwn/defi-mcp): DeFi & crypto MCP server — token prices, wallet balances, gas prices, DEX swap quotes across 7 chains.
 -   **[8144225309/superscalar-mcp](https://github.com/8144225309/superscalar-mcp)** [![GitHub stars](https://img.shields.io/github/stars/8144225309/superscalar-mcp?style=social)](https://github.com/8144225309/superscalar-mcp): Bitcoin Lightning channel factory MCP server — query protocol architecture, estimate UTXO savings, and explore channel factory infrastructure.
 -   **[xpaysh/awesome-x402](https://github.com/xpaysh/awesome-x402)** [![GitHub stars](https://img.shields.io/github/stars/xpaysh/awesome-x402?style=social)](https://github.com/xpaysh/awesome-x402): A curated directory of x402 payment protocol MCP servers and tools for HTTP-native USDC payments on EVM chains.
+-   **[lightningfaucet/lightning-wallet-mcp](https://github.com/lightningfaucet/lightning-wallet-mcp)** [![GitHub stars](https://img.shields.io/github/stars/lightningfaucet/lightning-wallet-mcp?style=social)](https://github.com/lightningfaucet/lightning-wallet-mcp): Gives AI agents a Bitcoin wallet with Lightning Network payments and L402 support.
 
 ### 🎮 Gaming
 


### PR DESCRIPTION
## Addition

Adds [Lightning Wallet MCP](https://github.com/lightningfaucet/lightning-wallet-mcp) to the **Finance & Fintech** section.

- **Name:** Lightning Wallet MCP
- **npm:** `lightning-wallet-mcp`
- **Description:** Gives AI agents a Bitcoin wallet with Lightning Network payments and L402 support

This MCP server enables AI agents to hold a Bitcoin balance, send/receive Lightning payments, and authenticate with L402 paywalled APIs — making it the first MCP server focused on Lightning Network wallet functionality.