### PR TITLE
Add WritBase to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[semgrep/mcp](https://github.com/semgrep/mcp)** [![GitHub stars](https://img.shields.io/github/stars/semgrep/mcp?style=social)](https://github.com/semgrep/mcp): A MCP server for using [Semgrep](https://github.com/semgrep/semgrep) to scan code for security vulnerabilities.
 -   **[@mastra/mcp-docs-server](https://github.com/mastra-ai/mastra/tree/main/packages/mcp-docs-server)** [![GitHub stars](https://img.shields.io/github/stars/mastra-ai/mastra?style=social)](https://github.com/mastra-ai/mastra/tree/main/packages/mcp-docs-server): Provides AI assistants with direct access to Mastra.ai's complete knowledge base.
 -   **[@mastra/mcp](https://github.com/mastra-ai/mastra/tree/main/packages/mcp)** [![GitHub stars](https://img.shields.io/github/stars/mastra-ai/mastra?style=social)](https://github.com/mastra-ai/mastra/tree/main/packages/mcp): Client implementation for Mastra, providing seamless integration with MCP-compatible AI models and tools.
+-   **[Writbase/writbase](https://github.com/Writbase/writbase)** [![GitHub stars](https://img.shields.io/github/stars/Writbase/writbase?style=social)](https://github.com/Writbase/writbase): MCP-native task management for AI agent fleets with multi-agent permissions and A2A protocol alignment.
 
 ### 🧮 Data Science Tools
 


### PR DESCRIPTION
## Summary
- Adds [WritBase](https://github.com/Writbase/writbase) to the Developer Tools section
- WritBase is an MCP-native task management control plane for AI agent fleets with multi-agent permissions and A2A protocol alignment

## Entry
Follows existing format with bold link, stars badge, and description.