### PR TITLE
Add onUI - UI Annotation MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[@automatalabs/mcp-server-playwright](https://github.com/Automata-Labs-team/MCP-Server-Playwright)** [![GitHub stars](https://img.shields.io/github/stars/Automata-Labs-team/MCP-Server-Playwright?style=social)](https://github.com/Automata-Labs-team/MCP-Server-Playwright): Controls web browsers via Playwright through MCP commands.
 -   **[modelcontextprotocol/server-puppeteer](https://github.com/modelcontextprotocol/servers/tree/main/src/puppeteer)** [![GitHub stars](https://img.shields.io/github/stars/modelcontextprotocol/servers?style=social)](https://github.com/modelcontextprotocol/servers): Automates web interactions and scraping using Puppeteer (part of the official servers collection).
 -   **[@kimtaeyoon83/mcp-server-youtube-transcript](https://github.com/kimtaeyoon83/mcp-server-youtube-transcript)** [![GitHub stars](https://img.shields.io/github/stars/kimtaeyoon83/mcp-server-youtube-transcript?style=social)](https://github.com/kimtaeyoon83/mcp-server-youtube-transcript): Extracts subtitles and transcripts from YouTube videos for AI processing.
+-   **[onllm-dev/onUI](https://github.com/onllm-dev/onUI)** [![GitHub stars](https://img.shields.io/github/stars/onllm-dev/onUI?style=social)](https://github.com/onllm-dev/onUI): Browser extension and MCP server for annotation-first UI pair programming with AI agents. 8 tools for listing pages, getting/searching annotations, generating reports, and managing annotation metadata.
 
 ### 🎨 Art & Culture
 


### PR DESCRIPTION
## Summary
- Adds [onUI](https://github.com/onllm-dev/onUI) to the Browser Control section
- onUI is a browser extension and MCP server for annotation-first UI pair programming with AI agents
- Provides 8 tools for listing pages, getting/searching annotations, generating reports, and managing annotation metadata
- Built with TypeScript, runs locally with no cloud backend

## Test plan
- [ ] Verify the entry format matches the existing list style
- [ ] Confirm the GitHub stars badge renders correctly
- [ ] Check that all links resolve properly