### PR TITLE
Add AgentRank to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[semgrep/mcp](https://github.com/semgrep/mcp)** [![GitHub stars](https://img.shields.io/github/stars/semgrep/mcp?style=social)](https://github.com/semgrep/mcp): A MCP server for using [Semgrep](https://github.com/semgrep/semgrep) to scan code for security vulnerabilities.
 -   **[@mastra/mcp-docs-server](https://github.com/mastra-ai/mastra/tree/main/packages/mcp-docs-server)** [![GitHub stars](https://img.shields.io/github/stars/mastra-ai/mastra?style=social)](https://github.com/mastra-ai/mastra/tree/main/packages/mcp-docs-server): Provides AI assistants with direct access to Mastra.ai's complete knowledge base.
 -   **[@mastra/mcp](https://github.com/mastra-ai/mastra/tree/main/packages/mcp)** [![GitHub stars](https://img.shields.io/github/stars/mastra-ai/mastra?style=social)](https://github.com/mastra-ai/mastra/tree/main/packages/mcp): Client implementation for Mastra, providing seamless integration with MCP-compatible AI models and tools.
+-   **[superlowburn/agentrank](https://github.com/superlowburn/agentrank)** [![GitHub stars](https://img.shields.io/github/stars/superlowburn/agentrank?style=social)](https://github.com/superlowburn/agentrank): Live, daily-scored index of 25,000+ MCP servers. Search and discover currently maintained tools ranked by real GitHub signals — freshness, issue health, contributors, dependents, and stars.
 
 ### 🧮 Data Science Tools
 


### PR DESCRIPTION
Adds [AgentRank](https://github.com/superlowburn/agentrank) to the **Developer Tools** section.

**What it does:** AgentRank is a live, daily-scored index of 25,000+ MCP servers. It ranks tools by real GitHub maintenance signals — freshness (days since last commit), issue health (closed/total ratio), contributors, dependents, and stars — so you can find tools that are actually maintained right now.

- **GitHub:** https://github.com/superlowburn/agentrank
- **npm:** [agentrank-mcp-server](https://www.npmjs.com/package/agentrank-mcp-server)
- **Website:** https://agentrank-ai.com
- **Install:** `npx -y agentrank-mcp-server`