### PR TITLE
Add wopee-mcp to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[semgrep/mcp](https://github.com/semgrep/mcp)** [![GitHub stars](https://img.shields.io/github/stars/semgrep/mcp?style=social)](https://github.com/semgrep/mcp): A MCP server for using [Semgrep](https://github.com/semgrep/semgrep) to scan code for security vulnerabilities.
 -   **[@mastra/mcp-docs-server](https://github.com/mastra-ai/mastra/tree/main/packages/mcp-docs-server)** [![GitHub stars](https://img.shields.io/github/stars/mastra-ai/mastra?style=social)](https://github.com/mastra-ai/mastra/tree/main/packages/mcp-docs-server): Provides AI assistants with direct access to Mastra.ai's complete knowledge base.
 -   **[@mastra/mcp](https://github.com/mastra-ai/mastra/tree/main/packages/mcp)** [![GitHub stars](https://img.shields.io/github/stars/mastra-ai/mastra?style=social)](https://github.com/mastra-ai/mastra/tree/main/packages/mcp): Client implementation for Mastra, providing seamless integration with MCP-compatible AI models and tools.
+-   **[wopee-mcp](https://www.npmjs.com/package/wopee-mcp)**: AI testing agents for web apps — dispatch test runs, analysis crawls, and AI agent tests.
 
 ### 🧮 Data Science Tools
 


### PR DESCRIPTION
Add [wopee-mcp](https://www.npmjs.com/package/wopee-mcp) — AI testing agents for web apps that dispatch test runs, analysis crawls, and AI agent tests via MCP.

- npm package: `wopee-mcp`
- Website: https://wopee.io

Added under the **Developer Tools** section.