### PR TITLE
Add iris-eval/mcp-server to Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[pydantic/logfire-mcp](https://github.com/pydantic/logfire-mcp)** [![GitHub stars](https://img.shields.io/github/stars/pydantic/logfire-mcp?style=social)](https://github.com/pydantic/logfire-mcp): Accesses OpenTelemetry traces and metrics through Logfire.
 -   **[seekrays/mcp-monitor](https://github.com/seekrays/mcp-monitor)** [![GitHub stars](https://img.shields.io/github/stars/seekrays/mcp-monitor?style=social)](https://github.com/seekrays/mcp-monitor): Provides system monitoring via MCP, exposing various metrics.
 -   **[hyperb1iss/lucidity-mcp](https://github.com/hyperb1iss/lucidity-mcp)** [![GitHub stars](https://img.shields.io/github/stars/hyperb1iss/lucidity-mcp?style=social)](https://github.com/hyperb1iss/lucidity-mcp): Provides intelligent, prompt-based analysis of AI-generated code across multiple dimensions.
+-   **[iris-eval/mcp-server](https://github.com/iris-eval/mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/iris-eval/mcp-server?style=social)](https://github.com/iris-eval/mcp-server): MCP-native agent eval & observability. Log traces, evaluate output quality with 12 built-in rules, and track per-agent costs. Zero code changes — agents discover Iris automatically.
 
 ### 🔎 Search
 


### PR DESCRIPTION
Adding [Iris](https://github.com/iris-eval/mcp-server) to the Monitoring section — MCP-native eval and observability. MIT licensed.