### PR TITLE
Add claw-mcp-toolkit to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[OzorOwn/defi-mcp](https://github.com/OzorOwn/defi-mcp)** [![GitHub stars](https://img.shields.io/github/stars/OzorOwn/defi-mcp?style=social)](https://github.com/OzorOwn/defi-mcp): DeFi & crypto MCP server — token prices, wallet balances, gas prices, DEX swap quotes across 7 chains.
 -   **[8144225309/superscalar-mcp](https://github.com/8144225309/superscalar-mcp)** [![GitHub stars](https://img.shields.io/github/stars/8144225309/superscalar-mcp?style=social)](https://github.com/8144225309/superscalar-mcp): Bitcoin Lightning channel factory MCP server — query protocol architecture, estimate UTXO savings, and explore channel factory infrastructure.
 -   **[xpaysh/awesome-x402](https://github.com/xpaysh/awesome-x402)** [![GitHub stars](https://img.shields.io/github/stars/xpaysh/awesome-x402?style=social)](https://github.com/xpaysh/awesome-x402): A curated directory of x402 payment protocol MCP servers and tools for HTTP-native USDC payments on EVM chains.
+-   **[ElromEvedElElyon/claw-mcp-toolkit](https://github.com/ElromEvedElElyon/claw-mcp-toolkit)** [![GitHub stars](https://img.shields.io/github/stars/ElromEvedElElyon/claw-mcp-toolkit?style=social)](https://github.com/ElromEvedElElyon/claw-mcp-toolkit): 26 tools across 5 modules (crypto, web, social, finance, productivity). Real-time crypto prices, web analysis, SEO checks, social content generation, portfolio tracking, and task management. Zero config, MIT license.
 
 ### 🎮 Gaming
 


### PR DESCRIPTION
Adding claw-mcp-toolkit - 26 tools across 5 modules (crypto, web, social, finance, productivity). Real-time crypto prices, web analysis, SEO checks, social content generation, portfolio tracking, and task management. Zero config, MIT license. Repo: https://github.com/ElromEvedElElyon/claw-mcp-toolkit