### PR TITLE
Add SkillFlow MCP Server - AI Skills Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[yuna0x0/anilist-mcp](https://github.com/yuna0x0/anilist-mcp)** [![GitHub stars](https://img.shields.io/github/stars/yuna0x0/anilist-mcp?style=social)](https://github.com/yuna0x0/anilist-mcp): Provides information on anime and manga through integration with the AniList API.
 -   **[austenstone/myinstants-mcp](https://github.com/austenstone/myinstants-mcp)** [![GitHub stars](https://img.shields.io/github/stars/austenstone/myinstants-mcp?style=social)](https://github.com/austenstone/myinstants-mcp): A soundboard MCP server with millions of meme sounds from myinstants.com. Search, play, and browse categories. `npx myinstants-mcp`
 
+- [SkillFlow MCP Server](https://github.com/rafsilva85/skillflow-mcp-server) - AI skills marketplace - search, discover, and install 500+ curated skills for coding agents. `npx skillflow-mcp-server`
+
 ### ☁️ Cloud Platforms
 
 -   **[cloudflare/mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare)** [![GitHub stars](https://img.shields.io/github/stars/cloudflare/mcp-server-cloudflare?style=social)](https://github.com/cloudflare/mcp-server-cloudflare): Integrates with various Cloudflare services like Workers and KV.


### PR DESCRIPTION
## SkillFlow MCP Server

Adding [SkillFlow](https://skillflow.builders) - an AI skills marketplace that connects coding agents to 500+ curated skills.

**Install:** `npx skillflow-mcp-server`

**Features:**
- Search and discover AI skills across categories
- Get featured/trending skills  
- Detailed install instructions for any skill
- Zero config - no API keys needed

**Published on:**
- [Official MCP Registry](https://registry.modelcontextprotocol.io) (Anthropic)
- [npm](https://www.npmjs.com/package/skillflow-mcp-server)
- [MCP Market](https://mcpmarket.com)

**GitHub:** https://github.com/rafsilva85/skillflow-mcp-server
