### PR TITLE
Add Cortex MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Note that this list is continuously updating and improving. Please star this rep
 
 ### 🧠 Knowledge & Memory
 
+-   **[SKULLFIRE07/cortex-memory](https://github.com/SKULLFIRE07/cortex-memory)** [![GitHub stars](https://img.shields.io/github/stars/SKULLFIRE07/cortex-memory?style=social)](https://github.com/SKULLFIRE07/cortex-memory): Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server.
 -   **[modelcontextprotocol/server-memory](https://github.com/modelcontextprotocol/servers/tree/main/src/memory)** [![GitHub stars](https://img.shields.io/github/stars/modelcontextprotocol/servers?style=social)](https://github.com/modelcontextprotocol/servers): Provides a knowledge graph-based persistent memory system (part of the official servers collection).
 -   **[CheMiguel23/MemoryMesh](https://github.com/CheMiguel23/MemoryMesh)** [![GitHub stars](https://img.shields.io/github/stars/CheMiguel23/MemoryMesh?style=social)](https://github.com/CheMiguel23/MemoryMesh): Provides enhanced graph-based memory focused on AI role-play.
 -   **[topoteretes/cognee-mcp](https://github.com/topoteretes/cognee/tree/dev/cognee-mcp)** [![GitHub stars](https://img.shields.io/github/stars/topoteretes/cognee?style=social)](https://github.com/topoteretes/cognee): Manages AI memory using graph/vector stores, with ingestion from 30+ data sources (part of Cognee project).


### PR DESCRIPTION
Cortex gives AI coding assistants persistent memory across sessions.

- GitHub: https://github.com/SKULLFIRE07/cortex-memory
- Marketplace: https://marketplace.visualstudio.com/items?itemName=cortex-dev.cortex-ai-memory
- MIT licensed