### PR TITLE
Add clipboard-mcp to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[@j4c0bs/mcp-server-sql-analyzer](https://github.com/j4c0bs/mcp-server-sql-analyzer)** [![GitHub stars](https://img.shields.io/github/stars/j4c0bs/mcp-server-sql-analyzer?style=social)](https://github.com/j4c0bs/mcp-server-sql-analyzer): Provides SQL analysis, linting, and dialect conversion using SQLGlot.
 -   **[0xshellming/mcp-summarizer](https://github.com/0xshellming/mcp-summarizer)** [![GitHub stars](https://img.shields.io/github/stars/0xshellming/mcp-summarizer?style=social)](https://github.com/0xshellming/mcp-summarizer): Provides AI summarization for multiple content types.
 -   **[SecretiveShell/MCP-timeserver](https://github.com/SecretiveShell/MCP-timeserver)** [![GitHub stars](https://img.shields.io/github/stars/SecretiveShell/MCP-timeserver?style=social)](https://github.com/SecretiveShell/MCP-timeserver): Provides the current time in any timezone.
+-   **[mnardit/clipboard-mcp](https://github.com/mnardit/clipboard-mcp)** [![GitHub stars](https://img.shields.io/github/stars/mnardit/clipboard-mcp?style=social)](https://github.com/mnardit/clipboard-mcp): Cross-platform system clipboard access (read, write, watch). Single Rust binary, zero runtime deps.
 
 
 ## Star History


### PR DESCRIPTION
Adds [clipboard-mcp](https://github.com/mnardit/clipboard-mcp) — cross-platform MCP server for system clipboard access.

- **Tools:** get_clipboard, set_clipboard, watch_clipboard
- **Platforms:** Windows, macOS, Linux (X11 + Wayland)
- **Stack:** Rust, single binary, zero runtime deps
- **Published:** [crates.io](https://crates.io/crates/clipboard-mcp), [MCP Registry](https://registry.modelcontextprotocol.io)