### PR TITLE
Add AIRIS MCP Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Note that this list is continuously updating and improving. Please star this rep
 
 ### 💻 Developer Tools
 
+-   **[agiletec-inc/airis-mcp-gateway](https://github.com/agiletec-inc/airis-mcp-gateway)** [![GitHub stars](https://img.shields.io/github/stars/agiletec-inc/airis-mcp-gateway?style=social)](https://github.com/agiletec-inc/airis-mcp-gateway): Docker-based MCP multiplexer exposing 60+ tools through 7 meta-tools. Reduces context tokens by 97%. One-command setup, auto-enables servers on demand.
 -   **[21st-dev/Magic-MCP](https://github.com/21st-dev/magic-mcp)** [![GitHub stars](https://img.shields.io/github/stars/21st-dev/magic-mcp?style=social)](https://github.com/21st-dev/magic-mcp): Generates UI components based on 21st.dev design principles.
 -   **[cocoindex-io/cocoindex-code](https://github.com/cocoindex-io/cocoindex-code)** [![GitHub stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex-code?style=social)](https://github.com/cocoindex-io/cocoindex-code): A super light-weight embedded MCP server for coding agents. Uses tree-sitter for code search and indexing, saves 70% tokens and improves speed.
 -   **[Comet-ML/Opik-MCP](https://github.com/comet-ml/opik-mcp)** [![GitHub stars](https://img.shields.io/github/stars/comet-ml/opik-mcp?style=social)](https://github.com/comet-ml/opik-mcp): Enables querying of LLM observability data captured by Opik.


### PR DESCRIPTION
## Summary

- Add [AIRIS MCP Gateway](https://github.com/agiletec-inc/airis-mcp-gateway) to the Developer Tools section
- Docker-based MCP multiplexer that exposes 60+ tools through 7 meta-tools, reducing context tokens by 97%
- One-command setup with auto-enable on demand

🤖 Generated with [Claude Code](https://claude.com/claude-code)