### PR TITLE
Add NEXO Brain - persistent memory MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[graphlit/graphlit-mcp-server](https://github.com/graphlit/graphlit-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/graphlit/graphlit-mcp-server?style=social)](https://github.com/graphlit/graphlit-mcp-server): Ingests data from various sources into a Graphlit project for searching and retrieval.
 -   **[CanopyHQ/phloem](https://github.com/CanopyHQ/phloem)** [![GitHub stars](https://img.shields.io/github/stars/CanopyHQ/phloem?style=social)](https://github.com/CanopyHQ/phloem): Local-first AI memory with causal graphs, citation verification, and zero network connections.
 -   **[omega-memory/core](https://github.com/omega-memory/core)** [![GitHub stars](https://img.shields.io/github/stars/omega-memory/core?style=social)](https://github.com/omega-memory/core): Persistent memory for AI coding agents with semantic search, auto-capture, intelligent forgetting, and cross-session learning. #1 on LongMemEval (95.4%). Local-first with zero cloud dependency.
+-   **[wazionapps/nexo](https://github.com/wazionapps/nexo)** [![GitHub stars](https://img.shields.io/github/stars/wazionapps/nexo?style=social)](https://github.com/wazionapps/nexo): Persistent memory system with cognitive architecture (Atkinson-Shiffrin model), session coordination, and 53+ tools for Claude Code. Features episodic memory, semantic RAG, trust scoring, and multi-terminal sync.
 
 ### 🗺️ Location Services
 


### PR DESCRIPTION
Adding [NEXO Brain](https://github.com/wazionapps/nexo) to Knowledge & Memory section. Persistent memory MCP server for Claude Code with Atkinson-Shiffrin cognitive architecture, 53+ tools, MIT license.