### PR TITLE
[codex] Add TicketLens Experiences MCP to Location Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[kukapay/nearby-search-mcp](https://github.com/kukapay/nearby-search-mcp)** [![GitHub stars](https://img.shields.io/github/stars/kukapay/nearby-search-mcp?style=social)](https://github.com/kukapay/nearby-search-mcp): Enables nearby place searches using IP-based location detection.
 
 -   **[IP2Location.io]** [![GitHub stars](https://img.shields.io/github/stars/ip2location/mcp-ip2location-io?style=social)](https://github.com/ip2location/mcp-ip2location-io): - IP2Location.io API integration to retrieve the geolocation information for an IP address.
+-   **[ticketlens/ticketlens-experiences-mcp](https://github.com/ticketlens/ticketlens-experiences-mcp)** [![GitHub stars](https://img.shields.io/github/stars/ticketlens/ticketlens-experiences-mcp?style=social)](https://github.com/ticketlens/ticketlens-experiences-mcp): Search tours, tickets, attractions, and activities for AI travel planners via hosted MCP or REST.
 
 ### 🎯 Marketing
 


### PR DESCRIPTION
## What changed
- add `ticketlens/ticketlens-experiences-mcp` to the `### 🗺️ Location Services` section
- use the repo's existing GitHub stars badge and concise one-line description format

## Why
TicketLens exposes a hosted remote MCP server and public REST API for destination experiences, which fits this list's location-services category for travel and place discovery workflows.

## Impact
This adds a discoverable MCP option for AI travel planners looking up tours, tickets, attractions, and activities.

## Validation
- verified the section placement and Markdown formatting locally
- ran `git diff --check`
