### PR TITLE
docs: withdraw the stale LLMKit listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[pydantic/logfire-mcp](https://github.com/pydantic/logfire-mcp)** [![GitHub stars](https://img.shields.io/github/stars/pydantic/logfire-mcp?style=social)](https://github.com/pydantic/logfire-mcp): Accesses OpenTelemetry traces and metrics through Logfire.
 -   **[seekrays/mcp-monitor](https://github.com/seekrays/mcp-monitor)** [![GitHub stars](https://img.shields.io/github/stars/seekrays/mcp-monitor?style=social)](https://github.com/seekrays/mcp-monitor): Provides system monitoring via MCP, exposing various metrics.
 -   **[hyperb1iss/lucidity-mcp](https://github.com/hyperb1iss/lucidity-mcp)** [![GitHub stars](https://img.shields.io/github/stars/hyperb1iss/lucidity-mcp?style=social)](https://github.com/hyperb1iss/lucidity-mcp): Provides intelligent, prompt-based analysis of AI-generated code across multiple dimensions.
+-   **[smigolsmigol/llmkit](https://github.com/smigolsmigol/llmkit)** [![GitHub stars](https://img.shields.io/github/stars/smigolsmigol/llmkit?style=social)](https://github.com/smigolsmigol/llmkit): AI cost tracking with 11 tools for spend analytics, budget enforcement, and session costs across Claude Code, Cursor, and Cline.
 
 ### 🔎 Search
 


### PR DESCRIPTION
## Status

Withdrawn.

## Reason

The product surface and public setup changed after this PR was opened, so the listing text is no longer a current merge candidate.

No maintainer action is requested.