### PR TITLE
Add MCP Trust Kit to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[@j4c0bs/mcp-server-sql-analyzer](https://github.com/j4c0bs/mcp-server-sql-analyzer)** [![GitHub stars](https://img.shields.io/github/stars/j4c0bs/mcp-server-sql-analyzer?style=social)](https://github.com/j4c0bs/mcp-server-sql-analyzer): Provides SQL analysis, linting, and dialect conversion using SQLGlot.
 -   **[0xshellming/mcp-summarizer](https://github.com/0xshellming/mcp-summarizer)** [![GitHub stars](https://img.shields.io/github/stars/0xshellming/mcp-summarizer?style=social)](https://github.com/0xshellming/mcp-summarizer): Provides AI summarization for multiple content types.
 -   **[SecretiveShell/MCP-timeserver](https://github.com/SecretiveShell/MCP-timeserver)** [![GitHub stars](https://img.shields.io/github/stars/SecretiveShell/MCP-timeserver?style=social)](https://github.com/SecretiveShell/MCP-timeserver): Provides the current time in any timezone.
+-   **[MCP Trust Kit](https://github.com/aak204/MCP-Trust-Kit)** [![GitHub stars](https://img.shields.io/github/stars/aak204/MCP-Trust-Kit?style=social)](https://github.com/aak204/MCP-Trust-Kit): Deterministic CI scanner and surface-risk scoring for MCP servers.
 
 
 ## Star History


### PR DESCRIPTION
Hi!

I'd like to suggest adding **MCP Trust Kit** to your awesome list.

It's an open-source, deterministic CI scanner that evaluates the surface risk (blast radius) of MCP servers before they are deployed to production. It checks for schema hygiene and flags dangerous capabilities (like filesystem mutation or shell execution).

-   Repo: https://github.com/aak204/MCP-Trust-Kit

Thank you for maintaining this valuable resource for the MCP community!