### PR TITLE
Add PreReason/mcp to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[OzorOwn/defi-mcp](https://github.com/OzorOwn/defi-mcp)** [![GitHub stars](https://img.shields.io/github/stars/OzorOwn/defi-mcp?style=social)](https://github.com/OzorOwn/defi-mcp): DeFi & crypto MCP server — token prices, wallet balances, gas prices, DEX swap quotes across 7 chains.
 -   **[8144225309/superscalar-mcp](https://github.com/8144225309/superscalar-mcp)** [![GitHub stars](https://img.shields.io/github/stars/8144225309/superscalar-mcp?style=social)](https://github.com/8144225309/superscalar-mcp): Bitcoin Lightning channel factory MCP server — query protocol architecture, estimate UTXO savings, and explore channel factory infrastructure.
 -   **[xpaysh/awesome-x402](https://github.com/xpaysh/awesome-x402)** [![GitHub stars](https://img.shields.io/github/stars/xpaysh/awesome-x402?style=social)](https://github.com/xpaysh/awesome-x402): A curated directory of x402 payment protocol MCP servers and tools for HTTP-native USDC payments on EVM chains.
+-   **[PreReason/mcp](https://github.com/PreReason/mcp)** [![GitHub stars](https://img.shields.io/github/stars/PreReason/mcp?style=social)](https://github.com/PreReason/mcp): Financial market context API that serves pre-analyzed briefings to AI agents. Covers BTC on-chain data, macro indicators, and cross-asset regime signals. Outputs markdown for efficient token usage. Also accessible via REST API and x402 micropayments.
 
 ### 🎮 Gaming
 


### PR DESCRIPTION
Adds PreReason to the Finance & Fintech section.

PreReason is a financial market context API. Instead of returning raw numbers, it delivers pre-analyzed briefings with trend direction, confidence scoring, and regime classification. Agents can consume the output directly without needing to build their own analysis layer.

- GitHub: [PreReason/mcp](https://github.com/PreReason/mcp)
- npm: [@prereason/mcp](https://www.npmjs.com/package/@prereason/mcp)
- Website: [prereason.com](https://www.prereason.com)
- License: MIT