### PR TITLE
Add Hindsight - AI agent memory by Vectorize

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[graphlit/graphlit-mcp-server](https://github.com/graphlit/graphlit-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/graphlit/graphlit-mcp-server?style=social)](https://github.com/graphlit/graphlit-mcp-server): Ingests data from various sources into a Graphlit project for searching and retrieval.
 -   **[CanopyHQ/phloem](https://github.com/CanopyHQ/phloem)** [![GitHub stars](https://img.shields.io/github/stars/CanopyHQ/phloem?style=social)](https://github.com/CanopyHQ/phloem): Local-first AI memory with causal graphs, citation verification, and zero network connections.
 -   **[omega-memory/core](https://github.com/omega-memory/core)** [![GitHub stars](https://img.shields.io/github/stars/omega-memory/core?style=social)](https://github.com/omega-memory/core): Persistent memory for AI coding agents with semantic search, auto-capture, intelligent forgetting, and cross-session learning. #1 on LongMemEval (95.4%). Local-first with zero cloud dependency.
+-   **[vectorize-io/hindsight](https://github.com/vectorize-io/hindsight)** [![GitHub stars](https://img.shields.io/github/stars/vectorize-io/hindsight?style=social)](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize, with retain/recall/reflect operations, multiple retrieval strategies, and an [MCP server integration](https://hindsight.vectorize.io/integrations). Open source and fully self-hostable.
 
 ### 🗺️ Location Services
 


### PR DESCRIPTION
## Summary
- Adds [Hindsight](https://github.com/vectorize-io/hindsight) to the **Knowledge & Memory** section
- Hindsight is a state-of-the-art, open-source long-term memory system for AI agents by Vectorize, featuring retain/recall/reflect operations, multiple retrieval strategies (semantic, BM25, graph, temporal), and an MCP server integration
- MIT-licensed and fully self-hostable (`pip install hindsight-all`)

## Why it fits
Hindsight provides an [MCP server integration](https://hindsight.vectorize.io/integrations) that gives AI agents persistent memory capabilities, making it a natural addition to this list's Knowledge & Memory section.