### PR TITLE
Add Nucleus MCP to Knowledge & Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[graphlit/graphlit-mcp-server](https://github.com/graphlit/graphlit-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/graphlit/graphlit-mcp-server?style=social)](https://github.com/graphlit/graphlit-mcp-server): Ingests data from various sources into a Graphlit project for searching and retrieval.
 -   **[CanopyHQ/phloem](https://github.com/CanopyHQ/phloem)** [![GitHub stars](https://img.shields.io/github/stars/CanopyHQ/phloem?style=social)](https://github.com/CanopyHQ/phloem): Local-first AI memory with causal graphs, citation verification, and zero network connections.
 -   **[omega-memory/core](https://github.com/omega-memory/core)** [![GitHub stars](https://img.shields.io/github/stars/omega-memory/core?style=social)](https://github.com/omega-memory/core): Persistent memory for AI coding agents with semantic search, auto-capture, intelligent forgetting, and cross-session learning. #1 on LongMemEval (95.4%). Local-first with zero cloud dependency.
+-   **[eidetic-works/nucleus-mcp](https://github.com/eidetic-works/nucleus-mcp)** [![GitHub stars](https://img.shields.io/github/stars/eidetic-works/nucleus-mcp?style=social)](https://github.com/eidetic-works/nucleus-mcp): 114 MCP tools for persistent memory, execution verification, governance, and compliance. Local-first with zero cloud dependencies.
 
 ### 🗺️ Location Services
 


### PR DESCRIPTION
## Summary

Adds [Nucleus MCP](https://github.com/eidetic-works/nucleus-mcp) to the **Knowledge & Memory** section.

- **114 MCP tools** for persistent memory, execution verification, governance, and compliance
- Local-first with zero cloud dependencies
- Published on [PyPI](https://pypi.org/project/mcp-server-nucleus/) and [npm](https://www.npmjs.com/package/mcp-server-nucleus)

Follows the existing list format exactly.