### PR TITLE
Add Access - self-hosted API gateway for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[semgrep/mcp](https://github.com/semgrep/mcp)** [![GitHub stars](https://img.shields.io/github/stars/semgrep/mcp?style=social)](https://github.com/semgrep/mcp): A MCP server for using [Semgrep](https://github.com/semgrep/semgrep) to scan code for security vulnerabilities.
 -   **[@mastra/mcp-docs-server](https://github.com/mastra-ai/mastra/tree/main/packages/mcp-docs-server)** [![GitHub stars](https://img.shields.io/github/stars/mastra-ai/mastra?style=social)](https://github.com/mastra-ai/mastra/tree/main/packages/mcp-docs-server): Provides AI assistants with direct access to Mastra.ai's complete knowledge base.
 -   **[@mastra/mcp](https://github.com/mastra-ai/mastra/tree/main/packages/mcp)** [![GitHub stars](https://img.shields.io/github/stars/mastra-ai/mastra?style=social)](https://github.com/mastra-ai/mastra/tree/main/packages/mcp): Client implementation for Mastra, providing seamless integration with MCP-compatible AI models and tools.
+-   **[Scottpedia0/access](https://github.com/Scottpedia0/access)** [![GitHub stars](https://img.shields.io/github/stars/Scottpedia0/access?style=social)](https://github.com/Scottpedia0/access): Self-hosted API gateway for AI agents. One Bearer token, all your services. OAuth, token refresh, audit logging — agents never touch credentials. Built-in MCP server.
 
 ### 🧮 Data Science Tools
 


### PR DESCRIPTION
## What is Access?

[Access](https://github.com/Scottpedia0/access) is a self-hosted API gateway for AI agents. One Bearer token, all your services. OAuth, token refresh, audit logging — agents never touch credentials. Built-in MCP server.

**Category:** Developer Tools

**Language:** TypeScript