### PR TITLE
Add get-engram/engram to Knowledge & Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[graphlit/graphlit-mcp-server](https://github.com/graphlit/graphlit-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/graphlit/graphlit-mcp-server?style=social)](https://github.com/graphlit/graphlit-mcp-server): Ingests data from various sources into a Graphlit project for searching and retrieval.
 -   **[CanopyHQ/phloem](https://github.com/CanopyHQ/phloem)** [![GitHub stars](https://img.shields.io/github/stars/CanopyHQ/phloem?style=social)](https://github.com/CanopyHQ/phloem): Local-first AI memory with causal graphs, citation verification, and zero network connections.
 -   **[omega-memory/core](https://github.com/omega-memory/core)** [![GitHub stars](https://img.shields.io/github/stars/omega-memory/core?style=social)](https://github.com/omega-memory/core): Persistent memory for AI coding agents with semantic search, auto-capture, intelligent forgetting, and cross-session learning. #1 on LongMemEval (95.4%). Local-first with zero cloud dependency.
+-   **[get-engram/engram](https://github.com/get-engram/engram)** [![GitHub stars](https://img.shields.io/github/stars/get-engram/engram?style=social)](https://github.com/get-engram/engram): Hosted memory service for AI agents that stores complete, verbatim conversation transcripts with semantic search. Cloudflare Workers + D1 + Vectorize. Free tier at mcp.getengram.app.
 
 ### 🗺️ Location Services
 


### PR DESCRIPTION
Adds [get-engram/engram](https://github.com/get-engram/engram) to the Knowledge & Memory section.

**What it is:** A hosted memory service for AI agents that stores complete, verbatim conversation transcripts and makes them searchable via semantic search. Unlike knowledge-graph or summary-based memory approaches, Engram preserves the full raw message history so agents can recall exactly what was said.

**Stack:** Cloudflare Workers + D1 + Vectorize + Workers AI embeddings. Hosted at https://mcp.getengram.app — free tier available, no self-hosting required.

**MCP tools:** `create_conversation`, `append_messages`, `search`, `list_conversations`, `get_conversation`, `delete_conversation`.