### PR TITLE
Add BulkPublish MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[arpitbatra123/mcp-googletasks](https://github.com/arpitbatra123/mcp-googletasks)** [![GitHub stars](https://img.shields.io/github/stars/arpitbatra123/mcp-googletasks?style=social)](https://github.com/arpitbatra123/mcp-googletasks): Interfaces with the Google Tasks API for task management.
 -   **[Eclipse-XV/twitch-mcp](https://github.com/Eclipse-XV/twitch-mcp)** [![GitHub stars](https://img.shields.io/github/stars/Eclipse-XV/twitch-mcp?style=social)](https://github.com/Eclipse-XV/twitch-mcp): Allows Twitch streamers to automate channel point predictions, trigger stream events, and extend interactive chat functionality.
 -   **[@taskade/mcp](https://github.com/taskade/mcp)** [![GitHub stars](https://img.shields.io/github/stars/taskade/mcp?style=social)](https://github.com/taskade/mcp): Official Taskade MCP server with 50+ tools for managing workspaces, projects, tasks, custom AI agents, and workflow automations. Includes OpenAPI-to-MCP codegen.
+-   **[@bulkpublish/mcp-server](https://github.com/azeemkafridi/bulkpublish-api/tree/main/mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/azeemkafridi/bulkpublish-api?style=social)](https://github.com/azeemkafridi/bulkpublish-api): MCP server for social media publishing across 11 platforms — create posts, schedule, upload media, and track analytics. 29 tools via `npx -y @bulkpublish/mcp-server`.
 
 ### 👤 Customer Data Platforms
 


### PR DESCRIPTION
Adds [BulkPublish MCP Server](https://github.com/azeemkafridi/bulkpublish-api/tree/main/mcp-server) to the Communication section.

**BulkPublish** is an MCP server for social media publishing across 11 platforms (Twitter/X, Facebook, Instagram, LinkedIn, TikTok, YouTube, Pinterest, Threads, Bluesky, Mastodon, Telegram). It provides 29 tools for creating posts, scheduling, uploading media, and tracking analytics.

- npm: `@bulkpublish/mcp-server`
- Install: `npx -y @bulkpublish/mcp-server`