### PR TITLE
Add Grovs to Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[henu-wang/geoscore-mcp](https://github.com/henu-wang/geoscore-mcp)** [![GitHub stars](https://img.shields.io/github/stars/henu-wang/geoscore-mcp?style=social)](https://github.com/henu-wang/geoscore-mcp): AI search optimization (GEO). Scans websites for AI search readiness, generates llms.txt, Schema.org fixes, and meta tag optimizations.
 -   **[bzsasson/screaming-frog-mcp](https://github.com/bzsasson/screaming-frog-mcp)** [![GitHub stars](https://img.shields.io/github/stars/bzsasson/screaming-frog-mcp?style=social)](https://github.com/bzsasson/screaming-frog-mcp): MCP server for Screaming Frog SEO Spider — list saved crawls, export SEO audit data, read and filter results, and manage crawl storage through natural language.
 -   **[open-strategy-partners/osp_marketing_tools](https://github.com/open-strategy-partners/osp_marketing_tools)** [![GitHub stars](https://img.shields.io/github/stars/open-strategy-partners/osp_marketing_tools?style=social)](https://github.com/open-strategy-partners/osp_marketing_tools): Provides a set of marketing tools from Open Strategy Partners.
+-   **[grovs-io/mcp](https://github.com/grovs-io/mcp)** [![GitHub stars](https://img.shields.io/github/stars/grovs-io/mcp?style=social)](https://github.com/grovs-io/mcp): Deep linking, attribution, analytics, and campaign management for mobile apps with Grovs — an open-source alternative to Branch and AppsFlyer.
 
 ### 📊 Monitoring
 


### PR DESCRIPTION
Adds [Grovs](https://grovs.io) to the Marketing section.

Grovs is an open-source, privacy-first deep linking, attribution, and analytics platform for mobile apps. The MCP server provides 16 tools for managing deep links, tracking installs and revenue, running campaigns, and configuring app settings.

- **Repo:** https://github.com/grovs-io/mcp
- **Remote endpoint:** `https://mcp.grovs.io/mcp` (Streamable HTTP + OAuth 2.1)
- **MIT licensed**