### PR TITLE
Add EnigmAgent to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[@j4c0bs/mcp-server-sql-analyzer](https://github.com/j4c0bs/mcp-server-sql-analyzer)** [![GitHub stars](https://img.shields.io/github/stars/j4c0bs/mcp-server-sql-analyzer?style=social)](https://github.com/j4c0bs/mcp-server-sql-analyzer): Provides SQL analysis, linting, and dialect conversion using SQLGlot.
 -   **[0xshellming/mcp-summarizer](https://github.com/0xshellming/mcp-summarizer)** [![GitHub stars](https://img.shields.io/github/stars/0xshellming/mcp-summarizer?style=social)](https://github.com/0xshellming/mcp-summarizer): Provides AI summarization for multiple content types.
 -   **[SecretiveShell/MCP-timeserver](https://github.com/SecretiveShell/MCP-timeserver)** [![GitHub stars](https://img.shields.io/github/stars/SecretiveShell/MCP-timeserver?style=social)](https://github.com/SecretiveShell/MCP-timeserver): Provides the current time in any timezone.
+-   **[Agnuxo1/enigmagent-mcp](https://github.com/Agnuxo1/enigmagent-mcp)** [![GitHub stars](https://img.shields.io/github/stars/Agnuxo1/enigmagent-mcp?style=social)](https://github.com/Agnuxo1/enigmagent-mcp): Encrypted local vault MCP server (AES-256-GCM + Argon2id) that resolves `{{PLACEHOLDER}}` secrets at runtime so API keys never appear in LLM prompts, logs, or context. Local-only, MIT, zero telemetry.
 
 
 ## Star History


### PR DESCRIPTION
Suggesting **EnigmAgent**, an open-source MCP server that fits this list cleanly.

It is an encrypted local vault that resolves `{{PLACEHOLDER}}` secrets at runtime so API keys never appear in LLM prompts, logs, or context windows. AES-256-GCM + Argon2id, local-only, MIT licensed.

- Repo: https://github.com/Agnuxo1/enigmagent-mcp
- npm: `npx enigmagent-mcp` — https://www.npmjs.com/package/enigmagent-mcp
- Glama security: A — https://glama.ai/mcp/servers/Agnuxo1/enigmagent-mcp

Happy to adjust the description, section, or format if you prefer.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>