### PR TITLE
Add prompt-to-asset to Art & Culture section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[r-huijts/rijksmuseum-mcp](https://github.com/r-huijts/rijksmuseum-mcp)** [![GitHub stars](https://img.shields.io/github/stars/r-huijts/rijksmuseum-mcp?style=social)](https://github.com/r-huijts/rijksmuseum-mcp): Connects to the Rijksmuseum API for accessing art collections and details.
 -   **[yuna0x0/anilist-mcp](https://github.com/yuna0x0/anilist-mcp)** [![GitHub stars](https://img.shields.io/github/stars/yuna0x0/anilist-mcp?style=social)](https://github.com/yuna0x0/anilist-mcp): Provides information on anime and manga through integration with the AniList API.
 -   **[austenstone/myinstants-mcp](https://github.com/austenstone/myinstants-mcp)** [![GitHub stars](https://img.shields.io/github/stars/austenstone/myinstants-mcp?style=social)](https://github.com/austenstone/myinstants-mcp): A soundboard MCP server with millions of meme sounds from myinstants.com. Search, play, and browse categories. `npx myinstants-mcp`
+-   **[MohamedAbdallah-14/prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset)** [![GitHub stars](https://img.shields.io/github/stars/MohamedAbdallah-14/prompt-to-asset?style=social)](https://github.com/MohamedAbdallah-14/prompt-to-asset): MCP server that generates production-ready visual assets (app icons, favicons, OG images, logos, wordmarks) by routing each request across 30+ image generation models. Zero API key for first run via free-tier providers.
 
 ### ☁️ Cloud Platforms
 


### PR DESCRIPTION
Adding prompt-to-asset to the Art & Culture section.

Prompt-to-asset is an MCP server that generates production-ready visual assets (app icons, favicons, OG images, logos, wordmarks) by routing each request across 30+ image generation models to find the best fit for the task. Zero API key for first run via free-tier providers (Pollinations, Stable Horde, HuggingFace). Three execution modes: inline SVG, external prompt, full API. MIT licensed.

GitHub: https://github.com/MohamedAbdallah-14/prompt-to-asset