### PR TITLE
Add TradeRouter/trade-router-mcp to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[OzorOwn/defi-mcp](https://github.com/OzorOwn/defi-mcp)** [![GitHub stars](https://img.shields.io/github/stars/OzorOwn/defi-mcp?style=social)](https://github.com/OzorOwn/defi-mcp): DeFi & crypto MCP server — token prices, wallet balances, gas prices, DEX swap quotes across 7 chains.
 -   **[8144225309/superscalar-mcp](https://github.com/8144225309/superscalar-mcp)** [![GitHub stars](https://img.shields.io/github/stars/8144225309/superscalar-mcp?style=social)](https://github.com/8144225309/superscalar-mcp): Bitcoin Lightning channel factory MCP server — query protocol architecture, estimate UTXO savings, and explore channel factory infrastructure.
 -   **[xpaysh/awesome-x402](https://github.com/xpaysh/awesome-x402)** [![GitHub stars](https://img.shields.io/github/stars/xpaysh/awesome-x402?style=social)](https://github.com/xpaysh/awesome-x402): A curated directory of x402 payment protocol MCP servers and tools for HTTP-native USDC payments on EVM chains.
+-   **[TradeRouter/trade-router-mcp](https://github.com/TradeRouter/trade-router-mcp)** [![GitHub stars](https://img.shields.io/github/stars/TradeRouter/trade-router-mcp?style=social)](https://github.com/TradeRouter/trade-router-mcp): Non-custodial Solana swap & limit-order MCP server for AI agents. 21 tools (swap, limit, trailing, TWAP, DCA, combo orders) across Raydium, PumpSwap, Orca, and Meteora. Jito MEV-protected. Ed25519 server-message verification. `npx -y @traderouter/trade-router-mcp`.
 
 ### 🎮 Gaming
 


### PR DESCRIPTION
Adds **TradeRouter/trade-router-mcp** to the Finance & Fintech section.

Non-custodial Solana swap & limit-order MCP server for AI agents:
- 21 tools (swap, limit, trailing, TWAP, DCA, and 4 combo orders)
- Multi-DEX routing: Raydium, PumpSwap, Orca, Meteora
- MEV-protected via Jito bundles
- Ed25519 server-message verification on order callbacks
- Private key never leaves the agent

Install: `npx -y @traderouter/trade-router-mcp`

Trust signals: VirusTotal 0/62 on v1.0.12, CI green Node 18/20/22, branch-protected, signed npm publishes, in the official MCP Registry as `ai.traderouter/trade-router-mcp@1.0.12` (`isLatest: true`), Glama listing (author-verified) at <https://glama.ai/mcp/servers/@traderouter/trade-router-mcp>.

Single-line addition matching the existing format (bold name + GitHub stars badge + description). Inserted at the end of the Finance & Fintech section.