### PR TITLE
Add voidly-ai/voidly-pay to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[OzorOwn/defi-mcp](https://github.com/OzorOwn/defi-mcp)** [![GitHub stars](https://img.shields.io/github/stars/OzorOwn/defi-mcp?style=social)](https://github.com/OzorOwn/defi-mcp): DeFi & crypto MCP server — token prices, wallet balances, gas prices, DEX swap quotes across 7 chains.
 -   **[8144225309/superscalar-mcp](https://github.com/8144225309/superscalar-mcp)** [![GitHub stars](https://img.shields.io/github/stars/8144225309/superscalar-mcp?style=social)](https://github.com/8144225309/superscalar-mcp): Bitcoin Lightning channel factory MCP server — query protocol architecture, estimate UTXO savings, and explore channel factory infrastructure.
 -   **[xpaysh/awesome-x402](https://github.com/xpaysh/awesome-x402)** [![GitHub stars](https://img.shields.io/github/stars/xpaysh/awesome-x402?style=social)](https://github.com/xpaysh/awesome-x402): A curated directory of x402 payment protocol MCP servers and tools for HTTP-native USDC payments on EVM chains.
+-   **[voidly-ai/voidly-pay](https://github.com/voidly-ai/voidly-pay)** [![GitHub stars](https://img.shields.io/github/stars/voidly-ai/voidly-pay?style=social)](https://github.com/voidly-ai/voidly-pay): Agent payment rail with x402 paywalls, escrow, streams, subscriptions, batch payouts, and a marketplace of 17 paid endpoints. USDC settlement on Base via Sourcify-verified vault. 42 MCP tools, free 10-credit faucet.
 
 ### 🎮 Gaming
 


### PR DESCRIPTION
Adding [voidly-ai/voidly-pay](https://github.com/voidly-ai/voidly-pay) to the Finance & Fintech section.

Agent-to-agent payment rail packaged as an MCP server. AI agents charge each other in USDC-backed credits over HTTP 402 (x402) with real settlement on Base mainnet.

- **npm:** `@voidly/pay-mcp` — 28 tools (wallet, transfer, escrow, hire, marketplace, x402 quote/verify, streams, subscriptions, webhooks, universal proxy, capability listing, faucet, trust scoring)
- **Universal proxy** — paywalls any public HTTPS URL with one query param (`/v1/pay/proxy?u=<url>&to=<did>&price=<usdc>`). No SDK install required on the URL owner's side.
- **USDC-backed:** Stage 2 vault on Base mainnet, source-verified on Sourcify. Public reserves dashboard at https://voidly.ai/pay/proof.
- **Live demo (no install):** https://huggingface.co/spaces/emperor-mew/voidly-pay

Install: `npx -y @voidly/pay-mcp`

200+ green tests, listed in the Anthropic MCP Registry. MIT licensed.