### PR TITLE
Add md-redline to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[semgrep/mcp](https://github.com/semgrep/mcp)** [![GitHub stars](https://img.shields.io/github/stars/semgrep/mcp?style=social)](https://github.com/semgrep/mcp): A MCP server for using [Semgrep](https://github.com/semgrep/semgrep) to scan code for security vulnerabilities.
 -   **[@mastra/mcp-docs-server](https://github.com/mastra-ai/mastra/tree/main/packages/mcp-docs-server)** [![GitHub stars](https://img.shields.io/github/stars/mastra-ai/mastra?style=social)](https://github.com/mastra-ai/mastra/tree/main/packages/mcp-docs-server): Provides AI assistants with direct access to Mastra.ai's complete knowledge base.
 -   **[@mastra/mcp](https://github.com/mastra-ai/mastra/tree/main/packages/mcp)** [![GitHub stars](https://img.shields.io/github/stars/mastra-ai/mastra?style=social)](https://github.com/mastra-ai/mastra/tree/main/packages/mcp): Client implementation for Mastra, providing seamless integration with MCP-compatible AI models and tools.
+-   **[dejuknow/md-redline](https://github.com/dejuknow/md-redline)** [![GitHub stars](https://img.shields.io/github/stars/dejuknow/md-redline?style=social)](https://github.com/dejuknow/md-redline): Inline review comments for markdown specs and design docs. Agents request human review mid-task via MCP and pause until you send feedback. Comments stored as invisible HTML markers in the markdown file itself.
 
 ### 🧮 Data Science Tools
 


### PR DESCRIPTION
Adds [md-redline](https://github.com/dejuknow/md-redline) under 💻 Developer Tools.

Local-first tool for inline review of markdown specs and design docs. Highlight text in the rendered document, leave feedback, and your AI agent reads the comments directly from the file. Built-in stdio MCP server (`mdr mcp`) lets agents request a review mid-task and pause until you send feedback.

- Repo: https://github.com/dejuknow/md-redline
- npm: https://www.npmjs.com/package/md-redline
- License: MIT
- Install: `npx md-redline /path/to/spec.md`

Comments are stored as invisible HTML markers in the markdown itself, so the same `.md` file is the source of truth for both human and agent.