### PR TITLE
Add nylas/cli under Communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[arpitbatra123/mcp-googletasks](https://github.com/arpitbatra123/mcp-googletasks)** [![GitHub stars](https://img.shields.io/github/stars/arpitbatra123/mcp-googletasks?style=social)](https://github.com/arpitbatra123/mcp-googletasks): Interfaces with the Google Tasks API for task management.
 -   **[Eclipse-XV/twitch-mcp](https://github.com/Eclipse-XV/twitch-mcp)** [![GitHub stars](https://img.shields.io/github/stars/Eclipse-XV/twitch-mcp?style=social)](https://github.com/Eclipse-XV/twitch-mcp): Allows Twitch streamers to automate channel point predictions, trigger stream events, and extend interactive chat functionality.
 -   **[@taskade/mcp](https://github.com/taskade/mcp)** [![GitHub stars](https://img.shields.io/github/stars/taskade/mcp?style=social)](https://github.com/taskade/mcp): Official Taskade MCP server with 50+ tools for managing workspaces, projects, tasks, custom AI agents, and workflow automations. Includes OpenAPI-to-MCP codegen.
+-   **[nylas/cli](https://github.com/nylas/cli)** [![GitHub stars](https://img.shields.io/github/stars/nylas/cli?style=social)](https://github.com/nylas/cli): MCP server for email, calendar, and contacts. 16 tools across Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP via one auth flow. Install with `nylas mcp install`. Docs: https://cli.nylas.com.
 
 ### 👤 Customer Data Platforms
 


### PR DESCRIPTION
Adds nylas/cli to the Communication section.

**What it is:** MCP server for email, calendar, and contacts. 16 tools across Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP behind one auth flow.

**Source:** https://github.com/nylas/cli
**Docs:** https://cli.nylas.com
**Install:** `brew install nylas/nylas-cli/nylas` then `nylas mcp install`