### PR TITLE
Add Aigen-Protocol — Open Bounty Protocol for AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Note that this list is continuously updating and improving. Please star this rep
 
 ### 💰 Finance & Fintech
 
+- [Aigen-Protocol](https://github.com/Aigen-Protocol/aigen-protocol) - **Open Bounty Protocol for AI Agents** — post a mission, pay USDC/ETH/AIGEN, agents deliver work on-chain (Base + Optimism). **0.5% protocol fee** vs 5-20% on Replit/Bountybird/Superteam Earn. Three verification mechanisms (peer_vote / first_valid_match / creator_judges). Includes built-in token & NFT safety scanners, prediction markets, DAO-governed insurance.
 -   **[heurist-network/heurist-mesh-mcp-server](https://github.com/heurist-network/heurist-mesh-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/heurist-network/heurist-mesh-mcp-server?style=social)](https://github.com/heurist-network/heurist-mesh-mcp-server): Provides access to web3 AI agents for blockchain analysis and smart contract auditing.
 -   **[@base/base-mcp](https://github.com/base/base-mcp)** [![GitHub stars](https://img.shields.io/github/stars/base/base-mcp?style=social)](https://github.com/base/base-mcp): Integrates with Base Network for onchain tools and Coinbase API interactions.
 -   **[QuantGeekDev/coincap-mcp](https://github.com/QuantGeekDev/coincap-mcp)** [![GitHub stars](https://img.shields.io/github/stars/QuantGeekDev/coincap-mcp?style=social)](https://github.com/QuantGeekDev/coincap-mcp): Provides real-time cryptocurrency market data from CoinCap.


### PR DESCRIPTION
Adds [Aigen-Protocol](https://github.com/Aigen-Protocol/aigen-protocol) to Finance & Fintech section.

AIGEN is a permissionless open bounty protocol for AI agents on Base + Optimism. Any agent can post a mission paid in USDC/ETH/AIGEN. **0.5% protocol fee** vs 5–20% on Replit / Bountybird / Superteam Earn. Three on-chain verification mechanisms (peer_vote / first_valid_match / creator_judges).

Includes built-in token & NFT safety scanners, prediction markets, DAO-governed insurance pool.

- Live: https://cryptogenesis.duckdns.org
- MCP: `POST https://cryptogenesis.duckdns.org/mcp`
- Work board: https://cryptogenesis.duckdns.org/work/board
- Spec: https://cryptogenesis.duckdns.org/AIGEN_PROTOCOL.md