### PR TITLE
Add @ethora/mcp-server to Communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[arpitbatra123/mcp-googletasks](https://github.com/arpitbatra123/mcp-googletasks)** [![GitHub stars](https://img.shields.io/github/stars/arpitbatra123/mcp-googletasks?style=social)](https://github.com/arpitbatra123/mcp-googletasks): Interfaces with the Google Tasks API for task management.
 -   **[Eclipse-XV/twitch-mcp](https://github.com/Eclipse-XV/twitch-mcp)** [![GitHub stars](https://img.shields.io/github/stars/Eclipse-XV/twitch-mcp?style=social)](https://github.com/Eclipse-XV/twitch-mcp): Allows Twitch streamers to automate channel point predictions, trigger stream events, and extend interactive chat functionality.
 -   **[@taskade/mcp](https://github.com/taskade/mcp)** [![GitHub stars](https://img.shields.io/github/stars/taskade/mcp?style=social)](https://github.com/taskade/mcp): Official Taskade MCP server with 50+ tools for managing workspaces, projects, tasks, custom AI agents, and workflow automations. Includes OpenAPI-to-MCP codegen.
+-   **[@ethora/mcp-server](https://github.com/dappros/ethora-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/dappros/ethora-mcp-server?style=social)](https://github.com/dappros/ethora-mcp-server): Official MCP server for the [Ethora](https://github.com/dappros/ethora) open-source chat & messaging platform — 80 tools for managing chat apps, deploying AI agents/chatbots with RAG, broadcasting messages, and B2B provisioning. Install via `npx -y @ethora/mcp-server`.
 
 ### 👤 Customer Data Platforms
 


### PR DESCRIPTION
Adds [`@ethora/mcp-server`](https://github.com/dappros/ethora-mcp-server) under **💬 Communication**.

Official MCP server for [Ethora](https://github.com/dappros/ethora), an open-source chat & messaging platform. 80 tools across:
- Chat app and chat-room management
- Message broadcast
- AI agent / chatbot lifecycle with OpenAI / OpenAI-compatible LLMs and RAG sources
- B2B / app-token workflows (one-call bootstrap: create app → index RAG sources → enable bot)

- npm: [`@ethora/mcp-server`](https://www.npmjs.com/package/@ethora/mcp-server)
- Official MCP Registry: `io.github.dappros/ethora-mcp-server`
- MIT licensed
- Install: `npx -y @ethora/mcp-server`