### PR TITLE
Add click-to-mcp to Command Line section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[MladenSU/cli-mcp-server](https://github.com/MladenSU/cli-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/MladenSU/cli-mcp-server?style=social)](https://github.com/MladenSU/cli-mcp-server): Offers a command-line interface with configurable security policies.
 -   **[tumf/mcp-shell-server](https://github.com/tumf/mcp-shell-server)** [![GitHub stars](https://img.shields.io/github/stars/tumf/mcp-shell-server?style=social)](https://github.com/tumf/mcp-shell-server): Securely executes shell commands through the Model Context Protocol.
 -   **[amol21p/mcp-interactive-terminal](https://github.com/amol21p/mcp-interactive-terminal)** [![GitHub stars](https://img.shields.io/github/stars/amol21p/mcp-interactive-terminal?style=social)](https://github.com/amol21p/mcp-interactive-terminal): Real interactive terminal sessions for REPLs, SSH, database clients, and any interactive CLI — with clean text output, smart completion detection, and multi-layer security.
+-   **[Coding-Dev-Tools/click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp)** [![GitHub stars](https://img.shields.io/github/stars/Coding-Dev-Tools/click-to-mcp?style=social)](https://github.com/Coding-Dev-Tools/click-to-mcp): Auto-wrap any Python Click/typer CLI as an MCP server with zero code changes.
 
 ### 💬 Communication
 


### PR DESCRIPTION
Added **[click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp)** to the 🖥️ Command Line section.

**click-to-mcp** auto-wraps any Python Click/typer CLI as an MCP server with zero code changes. Instead of rewriting CLI tools as MCP servers, developers can use click-to-mcp to wrap them automatically — enabling AI coding agents (Claude Code, Codex, Cursor) to interact with existing Python CLIs through MCP.

- Open source (MIT license)
- Available on PyPI
- Part of the [Revenue Holdings](https://coding-dev-tools.github.io/revenueholdings.dev/) developer tool ecosystem