### PR TITLE
Add evc-team-relay-mcp to Knowledge & Memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[graphlit/graphlit-mcp-server](https://github.com/graphlit/graphlit-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/graphlit/graphlit-mcp-server?style=social)](https://github.com/graphlit/graphlit-mcp-server): Ingests data from various sources into a Graphlit project for searching and retrieval.
 -   **[CanopyHQ/phloem](https://github.com/CanopyHQ/phloem)** [![GitHub stars](https://img.shields.io/github/stars/CanopyHQ/phloem?style=social)](https://github.com/CanopyHQ/phloem): Local-first AI memory with causal graphs, citation verification, and zero network connections.
 -   **[omega-memory/core](https://github.com/omega-memory/core)** [![GitHub stars](https://img.shields.io/github/stars/omega-memory/core?style=social)](https://github.com/omega-memory/core): Persistent memory for AI coding agents with semantic search, auto-capture, intelligent forgetting, and cross-session learning. #1 on LongMemEval (95.4%). Local-first with zero cloud dependency.
+-   **[entire-vc/evc-team-relay-mcp](https://github.com/entire-vc/evc-team-relay-mcp)** [![GitHub stars](https://img.shields.io/github/stars/entire-vc/evc-team-relay-mcp?style=social)](https://github.com/entire-vc/evc-team-relay-mcp): Gives AI agents read/write access to Obsidian vault documents via EVC Team Relay — a self-hosted CRDT-based collaborative sync server. Supports read, write, create, delete, and search across vault notes. Install with `uvx evc-team-relay-mcp`.
 
 ### 🗺️ Location Services
 


### PR DESCRIPTION
## What

Adding [evc-team-relay-mcp](https://github.com/entire-vc/evc-team-relay-mcp) to the **Knowledge & Memory** section.

## What is it?

An MCP server that gives AI agents read/write access to Obsidian vault documents via [EVC Team Relay](https://entire.vc/team-relay/ai/) — a self-hosted CRDT-based collaborative sync server.

**Key features:**
- List, read, write, create, delete, and search notes in connected Obsidian vaults
- Works with Claude Code, Cursor, and any MCP-compatible client
- Multi-agent collaborative access to shared vaults
- Available on PyPI: `uvx evc-team-relay-mcp`

**Links:** [GitHub](https://github.com/entire-vc/evc-team-relay-mcp) · [PyPI](https://pypi.org/project/evc-team-relay-mcp/) · [Smithery](https://smithery.ai/server/evc-team-relay-mcp)