### PR TITLE
feat: add evc-team-relay-mcp to Knowledge & Memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[graphlit/graphlit-mcp-server](https://github.com/graphlit/graphlit-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/graphlit/graphlit-mcp-server?style=social)](https://github.com/graphlit/graphlit-mcp-server): Ingests data from various sources into a Graphlit project for searching and retrieval.
 -   **[CanopyHQ/phloem](https://github.com/CanopyHQ/phloem)** [![GitHub stars](https://img.shields.io/github/stars/CanopyHQ/phloem?style=social)](https://github.com/CanopyHQ/phloem): Local-first AI memory with causal graphs, citation verification, and zero network connections.
 -   **[omega-memory/core](https://github.com/omega-memory/core)** [![GitHub stars](https://img.shields.io/github/stars/omega-memory/core?style=social)](https://github.com/omega-memory/core): Persistent memory for AI coding agents with semantic search, auto-capture, intelligent forgetting, and cross-session learning. #1 on LongMemEval (95.4%). Local-first with zero cloud dependency.
+-   **[entire-vc/evc-team-relay-mcp](https://github.com/entire-vc/evc-team-relay-mcp)** [![GitHub stars](https://img.shields.io/github/stars/entire-vc/evc-team-relay-mcp?style=social)](https://github.com/entire-vc/evc-team-relay-mcp): Collaborative Obsidian vault access via Team Relay — read, write, and sync notes with real-time CRDT-based conflict resolution.
 
 ### 🗺️ Location Services
 


### PR DESCRIPTION
Adds [evc-team-relay-mcp](https://github.com/entire-vc/evc-team-relay-mcp) to the Knowledge & Memory section.

MCP server for collaborative Obsidian vault access via Team Relay — read, write, and sync vault documents with real-time CRDT-based conflict resolution. Enables AI agents to work with personal knowledge bases stored in Obsidian.

- PyPI: \n- License: MIT | Python