### PR TITLE
feat: add benbencodes/llm-prices to Developer Tools — LLM API pricing CLI + MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Note that this list is continuously updating and improving. Please star this rep
 
 ### 💻 Developer Tools
 
+-   **[benbencodes/llm-prices](https://github.com/benbencodes/llm-prices)** [![GitHub stars](https://img.shields.io/github/stars/benbencodes/llm-prices?style=social)](https://github.com/benbencodes/llm-prices): Zero-dependency CLI and MCP server for comparing LLM API costs across 273 models and 44 providers. No API key needed — pricing data is baked in.
 -   **[21st-dev/Magic-MCP](https://github.com/21st-dev/magic-mcp)** [![GitHub stars](https://img.shields.io/github/stars/21st-dev/magic-mcp?style=social)](https://github.com/21st-dev/magic-mcp): Generates UI components based on 21st.dev design principles.
 -   **[cocoindex-io/cocoindex-code](https://github.com/cocoindex-io/cocoindex-code)** [![GitHub stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex-code?style=social)](https://github.com/cocoindex-io/cocoindex-code): A super light-weight embedded MCP server for coding agents. Uses tree-sitter for code search and indexing, saves 70% tokens and improves speed.
 -   **[Comet-ML/Opik-MCP](https://github.com/comet-ml/opik-mcp)** [![GitHub stars](https://img.shields.io/github/stars/comet-ml/opik-mcp?style=social)](https://github.com/comet-ml/opik-mcp): Enables querying of LLM observability data captured by Opik.


### PR DESCRIPTION
## What this adds

**[llm-prices](https://github.com/benbencodes/llm-prices)** — a zero-dependency Python CLI and MCP server for comparing LLM API costs across providers.

### Why it fits Developer Tools

- **MCP server built-in** (`llm-prices-mcp`): integrates directly with Claude, Cursor, and other AI assistants
- **273 models, 44 providers**: OpenAI, Anthropic, Google, Mistral, DeepSeek, xAI, Qwen, NVIDIA, IBM, Perceptron, and more
- **No API key needed**: pricing data baked in, works offline
- Practical for any AI developer who needs to compare/calculate LLM costs without visiting 44 pricing pages

### Format check

Follows the existing entry format:  
`-   **[Owner/Repo](url)** [![stars badge](url)]: Description.`

### Link

https://github.com/benbencodes/llm-prices