### PR TITLE
Add Doxa MCP: Christian AI, Bible lookup, encouragement

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[graphlit/graphlit-mcp-server](https://github.com/graphlit/graphlit-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/graphlit/graphlit-mcp-server?style=social)](https://github.com/graphlit/graphlit-mcp-server): Ingests data from various sources into a Graphlit project for searching and retrieval.
 -   **[CanopyHQ/phloem](https://github.com/CanopyHQ/phloem)** [![GitHub stars](https://img.shields.io/github/stars/CanopyHQ/phloem?style=social)](https://github.com/CanopyHQ/phloem): Local-first AI memory with causal graphs, citation verification, and zero network connections.
 -   **[omega-memory/core](https://github.com/omega-memory/core)** [![GitHub stars](https://img.shields.io/github/stars/omega-memory/core?style=social)](https://github.com/omega-memory/core): Persistent memory for AI coding agents with semantic search, auto-capture, intelligent forgetting, and cross-session learning. #1 on LongMemEval (95.4%). Local-first with zero cloud dependency.
+-   **[The-Doxa-Way/doxa-mcp-schema](https://github.com/The-Doxa-Way/doxa-mcp-schema)** [![GitHub stars](https://img.shields.io/github/stars/The-Doxa-Way/doxa-mcp-schema?style=social)](https://github.com/The-Doxa-Way/doxa-mcp-schema): Christian AI encouragement, Bible verse lookup (Berean Standard Bible, 31,000+ verses), and the Doxa Way journey map. Hosted at `https://doxa.app/mcp/v1`.
 
 ### 🗺️ Location Services
 


### PR DESCRIPTION
## What is Doxa MCP?

[Doxa MCP](https://github.com/The-Doxa-Way/doxa-mcp-schema) is a hosted MCP server that brings Christian encouragement and Scripture to any AI assistant, for any season.

**Endpoint:** `https://doxa.app/mcp/v1`

### Three tools

| Tool | Purpose |
|------|---------|
| `doxa_encourage` | Encouragement anchored in Scripture for any life situation |
| `doxa_scripture` | Bible verse lookup — Berean Standard Bible, 31,000+ verses |
| `doxa_way_movement` | The Doxa Way journey map (Hear, Discern, Record, Remember, Trust) |

### Why include it?

- **Listed in the Anthropic MCP Registry** (v1.0.3) — vetted and discoverable at [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io)
- **faith.tools 5/5** with public transcripts — [faith.tools/tools/doxa-mcp](https://faith.tools/tools/doxa-mcp)
- Hosted (no local install), works with Claude Desktop, Cursor, Windsurf, and any MCP client
- Schema repo: [The-Doxa-Way/doxa-mcp-schema](https://github.com/The-Doxa-Way/doxa-mcp-schema)

Added to the **Knowledge & Memory** section as it provides a structured knowledge corpus (31,000+ Bible verses) with contextual retrieval.