### PR TITLE
feat: The Stall — 210 pay-per-call AI capabilities via x402 MCP (v4.64.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[OzorOwn/defi-mcp](https://github.com/OzorOwn/defi-mcp)** [![GitHub stars](https://img.shields.io/github/stars/OzorOwn/defi-mcp?style=social)](https://github.com/OzorOwn/defi-mcp): DeFi & crypto MCP server — token prices, wallet balances, gas prices, DEX swap quotes across 7 chains.
 -   **[8144225309/superscalar-mcp](https://github.com/8144225309/superscalar-mcp)** [![GitHub stars](https://img.shields.io/github/stars/8144225309/superscalar-mcp?style=social)](https://github.com/8144225309/superscalar-mcp): Bitcoin Lightning channel factory MCP server — query protocol architecture, estimate UTXO savings, and explore channel factory infrastructure.
 -   **[xpaysh/awesome-x402](https://github.com/xpaysh/awesome-x402)** [![GitHub stars](https://img.shields.io/github/stars/xpaysh/awesome-x402?style=social)](https://github.com/xpaysh/awesome-x402): A curated directory of x402 payment protocol MCP servers and tools for HTTP-native USDC payments on EVM chains.
+-   **[thebrierfox/the-stall](https://github.com/thebrierfox/the-stall)** [![GitHub stars](https://img.shields.io/github/stars/thebrierfox/the-stall?style=social)](https://github.com/thebrierfox/the-stall): Remote x402 pay-per-call MCP capability chassis with 172 tools: US stock prices, options chains, DeFi yields, DEX quotes, crypto/macro data, on-chain wallet analysis, Solana & EVM tx decoding — USDC on Base mainnet, no API key required.
 
 ### 🎮 Gaming
 


### PR DESCRIPTION
## The Stall — 210 pay-per-call AI capabilities (v4.64.0)

**Live:** https://the-stall.intuitek.ai | **MCP:** https://the-stall.intuitek.ai/mcp

The Stall is an x402 MCP server with 210 pay-per-call capabilities — AI agents pay USDC per call, no API keys needed.

**Coverage:** stocks, crypto, DeFi, insider trades, Form 144 planned sales, options, macro, congressional trades, weather, cron tools, domain intel, and 185+ more.

**New in v4.64.0:**
- `form-144-intel` — SEC Form 144 planned insider sale filings (pre-Form 4 signal, from EDGAR)
- `cron-parser` — parse and explain cron expressions, return next N run times

```json
{
  "mcpServers": {
    "the-stall": {
      "type": "streamable-http",
      "url": "https://the-stall.intuitek.ai/mcp"
    }
  }
}
```

git: d25c40a | version: v4.64.0 | caps: 210
