### PR TITLE
Add domain-monitor-mcp-server to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[seekrays/mcp-monitor](https://github.com/seekrays/mcp-monitor)** [![GitHub stars](https://img.shields.io/github/stars/seekrays/mcp-monitor?style=social)](https://github.com/seekrays/mcp-monitor): Provides system monitoring via MCP, exposing various metrics.
 -   **[hyperb1iss/lucidity-mcp](https://github.com/hyperb1iss/lucidity-mcp)** [![GitHub stars](https://img.shields.io/github/stars/hyperb1iss/lucidity-mcp?style=social)](https://github.com/hyperb1iss/lucidity-mcp): Provides intelligent, prompt-based analysis of AI-generated code across multiple dimensions.
 
+
+-   **[@iPythoning/domain-monitor-mcp-server](https://github.com/iPythoning/domain-monitor-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/iPythoning/domain-monitor-mcp-server?style=social)](https://github.com/iPythoning/domain-monitor-mcp-server): Domain WHOIS and SSL certificate monitoring via RDAP and crt.sh — single or batch domain checks with severity classification. Zero API keys, stdio transport. Install: `npx domain-monitor-mcp-server`.
+
 ### 🔎 Search
 
 -   **[modelcontextprotocol/server-brave-search](https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search)** [![GitHub stars](https://img.shields.io/github/stars/modelcontextprotocol/servers?style=social)](https://github.com/modelcontextprotocol/servers): Performs web searches using Brave's Search API (part of the official servers collection).


### PR DESCRIPTION
Adds [iPythoning/domain-monitor-mcp-server](https://github.com/iPythoning/domain-monitor-mcp-server) to the 📊 Monitoring section.

**What it does**: MCP server for domain monitoring — check WHOIS registration expiry via RDAP and SSL/TLS certificate expiry via crt.sh. Supports single domain and batch domain checks with severity classification.

**Key features**: Zero API keys (public RDAP + crt.sh), stdio transport, TypeScript/Node.js. Install: `npx domain-monitor-mcp-server`.