### PR TITLE
Add scala-mcp-server to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[OzorOwn/defi-mcp](https://github.com/OzorOwn/defi-mcp)** [![GitHub stars](https://img.shields.io/github/stars/OzorOwn/defi-mcp?style=social)](https://github.com/OzorOwn/defi-mcp): DeFi & crypto MCP server — token prices, wallet balances, gas prices, DEX swap quotes across 7 chains.
 -   **[8144225309/superscalar-mcp](https://github.com/8144225309/superscalar-mcp)** [![GitHub stars](https://img.shields.io/github/stars/8144225309/superscalar-mcp?style=social)](https://github.com/8144225309/superscalar-mcp): Bitcoin Lightning channel factory MCP server — query protocol architecture, estimate UTXO savings, and explore channel factory infrastructure.
 -   **[xpaysh/awesome-x402](https://github.com/xpaysh/awesome-x402)** [![GitHub stars](https://img.shields.io/github/stars/xpaysh/awesome-x402?style=social)](https://github.com/xpaysh/awesome-x402): A curated directory of x402 payment protocol MCP servers and tools for HTTP-native USDC payments on EVM chains.
+-   **[Alessandro114/scala-mcp-server](https://github.com/Alessandro114/scala-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/Alessandro114/scala-mcp-server?style=social)](https://github.com/Alessandro114/scala-mcp-server): Search and enrich data from 250M+ companies across 50+ countries. Company lookup by name/VAT/ID, sector search, financial data.
 
 ### 🎮 Gaming
 


### PR DESCRIPTION
## Summary

- Adds [scala-mcp-server](https://github.com/Alessandro114/scala-mcp-server) to the **Finance & Fintech** section
- MCP server for searching and enriching data from **250M+ companies** across **50+ countries**
- Features: company lookup by name/VAT/ID, sector search, financial data
- Available on [npm](https://www.npmjs.com/package/scala-mcp-server)

Entry follows the existing format with name, GitHub stars badge, and description.