### PR TITLE
add screenpipe to knowledge & memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[graphlit/graphlit-mcp-server](https://github.com/graphlit/graphlit-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/graphlit/graphlit-mcp-server?style=social)](https://github.com/graphlit/graphlit-mcp-server): Ingests data from various sources into a Graphlit project for searching and retrieval.
 -   **[CanopyHQ/phloem](https://github.com/CanopyHQ/phloem)** [![GitHub stars](https://img.shields.io/github/stars/CanopyHQ/phloem?style=social)](https://github.com/CanopyHQ/phloem): Local-first AI memory with causal graphs, citation verification, and zero network connections.
 -   **[omega-memory/core](https://github.com/omega-memory/core)** [![GitHub stars](https://img.shields.io/github/stars/omega-memory/core?style=social)](https://github.com/omega-memory/core): Persistent memory for AI coding agents with semantic search, auto-capture, intelligent forgetting, and cross-session learning. #1 on LongMemEval (95.4%). Local-first with zero cloud dependency.
+-   **[screenpipe/screenpipe](https://github.com/screenpipe/screenpipe)** [![GitHub stars](https://img.shields.io/github/stars/screenpipe/screenpipe?style=social)](https://github.com/screenpipe/screenpipe): Local-first memory of everything you have seen, said, and heard — records and indexes your screen (OCR + accessibility) and audio so an agent can search your real activity. `npx -y screenpipe-mcp`, fully on-device.
 
 ### 🗺️ Location Services
 


### PR DESCRIPTION
adds screenpipe to knowledge & memory. local-first memory layer that records + indexes your screen and audio so an agent can search your real activity over MCP (npx -y screenpipe-mcp), fully on-device. matched the section style, not already listed.