### PR TITLE
Add HumanHours MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[pydantic/logfire-mcp](https://github.com/pydantic/logfire-mcp)** [![GitHub stars](https://img.shields.io/github/stars/pydantic/logfire-mcp?style=social)](https://github.com/pydantic/logfire-mcp): Accesses OpenTelemetry traces and metrics through Logfire.
 -   **[seekrays/mcp-monitor](https://github.com/seekrays/mcp-monitor)** [![GitHub stars](https://img.shields.io/github/stars/seekrays/mcp-monitor?style=social)](https://github.com/seekrays/mcp-monitor): Provides system monitoring via MCP, exposing various metrics.
 -   **[hyperb1iss/lucidity-mcp](https://github.com/hyperb1iss/lucidity-mcp)** [![GitHub stars](https://img.shields.io/github/stars/hyperb1iss/lucidity-mcp?style=social)](https://github.com/hyperb1iss/lucidity-mcp): Provides intelligent, prompt-based analysis of AI-generated code across multiple dimensions.
+-   **[triadgit/humanhours-mcp](https://github.com/triadgit/humanhours-mcp)** [![GitHub stars](https://img.shields.io/github/stars/triadgit/humanhours-mcp?style=social)](https://github.com/triadgit/humanhours-mcp): Tracks agent ROI (hours and money saved) and enriches companies into roles and per-hour wages. Remote, OAuth 2.1, no install (`https://mcp.humanhours.dev/mcp`).
 
 ### 🔎 Search
 


### PR DESCRIPTION
Adds HumanHours under Monitoring.

HumanHours is a remote MCP server for tracking AI-agent ROI (hours and money saved) and enriching companies into roles + per-hour wages.

- Repo: https://github.com/triadgit/humanhours-mcp
- Endpoint: https://mcp.humanhours.dev/mcp (streamable HTTP, OAuth 2.1, no install, no API keys)
- Registry id: dev.humanhours/humanhours
- Docs: https://humanhours.dev/docs/mcp