### PR TITLE
Add Public Grants MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[OzorOwn/defi-mcp](https://github.com/OzorOwn/defi-mcp)** [![GitHub stars](https://img.shields.io/github/stars/OzorOwn/defi-mcp?style=social)](https://github.com/OzorOwn/defi-mcp): DeFi & crypto MCP server — token prices, wallet balances, gas prices, DEX swap quotes across 7 chains.
 -   **[8144225309/superscalar-mcp](https://github.com/8144225309/superscalar-mcp)** [![GitHub stars](https://img.shields.io/github/stars/8144225309/superscalar-mcp?style=social)](https://github.com/8144225309/superscalar-mcp): Bitcoin Lightning channel factory MCP server — query protocol architecture, estimate UTXO savings, and explore channel factory infrastructure.
 -   **[xpaysh/awesome-x402](https://github.com/xpaysh/awesome-x402)** [![GitHub stars](https://img.shields.io/github/stars/xpaysh/awesome-x402?style=social)](https://github.com/xpaysh/awesome-x402): A curated directory of x402 payment protocol MCP servers and tools for HTTP-native USDC payments on EVM chains.
+-   **[Public Grants](https://grants.mrchief.ai)**: French public grants advisor for startups and AI agents. 21 tools for profile onboarding (SIRENE pre-fill, auto-enrichment + customisable input), eligibility check across 49 programmes (CIR, JEI, BPI, CNC, ADEME, EIC Accelerator), application drafting (.md/.docx export), and free strategic briefing PDF. Traditional consultants charge EUR 2,000-5,000 - Public Grants: free discovery, EUR 49/dossier. Remote Streamable HTTP at grants.mrchief.ai/mcp/.
 
 ### 🎮 Gaming
 


### PR DESCRIPTION
Adds Public Grants under Finance & Fintech.

Public Grants is a remote MCP server that helps French startups find and apply for public funding. It replaces EUR 2,000-5,000 grant consultants with 21 MCP tools at EUR 49/dossier, free discovery included.

- Endpoint: https://grants.mrchief.ai/mcp/ (Streamable HTTP, no auth for discovery)
- 21 tools + 3 guided prompts: onboarding (SIRENE pre-fill, auto-enrichment + customisable input), discovery (49 programmes, per-rule eligibility from official legal texts), drafting (.md/.docx export), strategic briefing (free PDF)
- 49 programmes across 5 verticals: Tech (CIR, JEI, i-Nov), Culture (CNC, CNM), Climate (ADEME), EU (EIC Accelerator), Regional (Innov'Up, PM'up)
- EU-hosted (Fly.io Paris + Supabase Frankfurt), RGPD compliant
- Source code on GitLab (private repo) - no GitHub stars badge
- Built by [PyratzLabs](https://pyratzlabs.com)

Happy to reword or adjust the entry.