### PR TITLE
Add HyperSpace — MCP hybrid inference router

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[semgrep/mcp](https://github.com/semgrep/mcp)** [![GitHub stars](https://img.shields.io/github/stars/semgrep/mcp?style=social)](https://github.com/semgrep/mcp): A MCP server for using [Semgrep](https://github.com/semgrep/semgrep) to scan code for security vulnerabilities.
 -   **[@mastra/mcp-docs-server](https://github.com/mastra-ai/mastra/tree/main/packages/mcp-docs-server)** [![GitHub stars](https://img.shields.io/github/stars/mastra-ai/mastra?style=social)](https://github.com/mastra-ai/mastra/tree/main/packages/mcp-docs-server): Provides AI assistants with direct access to Mastra.ai's complete knowledge base.
 -   **[@mastra/mcp](https://github.com/mastra-ai/mastra/tree/main/packages/mcp)** [![GitHub stars](https://img.shields.io/github/stars/mastra-ai/mastra?style=social)](https://github.com/mastra-ai/mastra/tree/main/packages/mcp): Client implementation for Mastra, providing seamless integration with MCP-compatible AI models and tools.
+-   **[@freerunningkid/HyperSpace](https://github.com/freerunningkid/HyperSpace)** [![GitHub stars](https://img.shields.io/github/stars/freerunningkid/HyperSpace?style=social)](https://github.com/freerunningkid/HyperSpace): MCP hybrid inference router — native DeepSeek Web client (zero-cost, thinking + search) → DeepSeek API (low-cost) → Zhipu GLM (free fallback). Zero-token rule-based routing with 202 unit tests.
 
 ### 🧮 Data Science Tools
 


### PR DESCRIPTION
## Description

Add [HyperSpace](https://github.com/freerunningkid/HyperSpace) to the **Developer Tools** section.

### What is HyperSpace?
HyperSpace is an MCP hybrid inference router that lets local AI agents (Claude Code, VS Code, Cline, etc.) query LLMs through a three-tier chain:
1. **DeepSeek Web** (native Python client, $0, with thinking + web search) 
2. **DeepSeek API** (low-cost)
3. **Zhipu GLM** (free fallback)

### Why it's unique
- Not an API proxy — it's a **native DeepSeek Web client** that directly calls chat.deepseek.com's internal API (PoW solving, SSE streaming, file upload)
- Zero-token rule-based routing (7-dimension task analysis)
- 202 unit tests, CI passing on Python 3.10-3.13
- MIT licensed