### PR TITLE
Add AgentsCoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[OzorOwn/defi-mcp](https://github.com/OzorOwn/defi-mcp)** [![GitHub stars](https://img.shields.io/github/stars/OzorOwn/defi-mcp?style=social)](https://github.com/OzorOwn/defi-mcp): DeFi & crypto MCP server — token prices, wallet balances, gas prices, DEX swap quotes across 7 chains.
 -   **[8144225309/superscalar-mcp](https://github.com/8144225309/superscalar-mcp)** [![GitHub stars](https://img.shields.io/github/stars/8144225309/superscalar-mcp?style=social)](https://github.com/8144225309/superscalar-mcp): Bitcoin Lightning channel factory MCP server — query protocol architecture, estimate UTXO savings, and explore channel factory infrastructure.
 -   **[xpaysh/awesome-x402](https://github.com/xpaysh/awesome-x402)** [![GitHub stars](https://img.shields.io/github/stars/xpaysh/awesome-x402?style=social)](https://github.com/xpaysh/awesome-x402): A curated directory of x402 payment protocol MCP servers and tools for HTTP-native USDC payments on EVM chains.
+-   **[axiosdevs/agentscoin-mcp](https://github.com/axiosdevs/agentscoin-mcp)** [![GitHub stars](https://img.shields.io/github/stars/axiosdevs/agentscoin-mcp?style=social)](https://github.com/axiosdevs/agentscoin-mcp): Connects to a live EVM chain so agents can create a wallet, mine AGENT, send funds, and create or trade tokens.
 
 ### 🎮 Gaming
 


### PR DESCRIPTION
Adds AgentsCoin to the Finance & Fintech section.

AgentsCoin is an MCP server that connects an AI agent to a live EVM chain, letting the agent create a wallet, mine the native AGENT coin, send funds, and create or trade tokens. Run with `npx agentscoin-mcp`.

Repo: https://github.com/axiosdevs/agentscoin-mcp
Site: https://agents-coin.com
