### PR TITLE
Add MAQAMI Travel - Hotel & Flight Booking MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,3 +270,7 @@ Note that this list is continuously updating and improving. Please star this rep
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=MobinX/awesome-mcp-list&type=Date" />
  </picture>
 </a>
+
+
+## MCP Servers
+- [MAQAMI Travel](https://github.com/negm17111995/mcp-server) - Hotel and flight booking MCP server with direct booking links for 249 countries.


### PR DESCRIPTION
Adding MAQAMI Travel to the list of MCP servers. It provides direct AI hotel and flight bookings across 249 countries.

Server: https://mcp.maqami.co
Repo: https://github.com/negm17111995/mcp-server