### PR TITLE
Add AgentServices — x402 Finance & Data APIs for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Note that this list is continuously updating and improving. Please star this rep
 ### 💰 Finance & Fintech
 
 -   **[heurist-network/heurist-mesh-mcp-server](https://github.com/heurist-network/heurist-mesh-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/heurist-network/heurist-mesh-mcp-server?style=social)](https://github.com/heurist-network/heurist-mesh-mcp-server): Provides access to web3 AI agents for blockchain analysis and smart contract auditing.
-- [AgentServices](https://github.com/vbkotecha/aiservices-api) — Paid APIs for AI agents. Crypto prices, DeFi yields, indicators, dispute resolution. x402 on Base. MCP at api.aiservices.to/mcp.
+- [AgentServices](https://github.com/vbkotecha/aiservices-api) — Paid APIs for AI agents. Crypto prices, DeFi yields, indicators, dispute resolution. x402 on Base. MCP at agentservices.to/mcp.
 -   **[@base/base-mcp](https://github.com/base/base-mcp)** [![GitHub stars](https://img.shields.io/github/stars/base/base-mcp?style=social)](https://github.com/base/base-mcp): Integrates with Base Network for onchain tools and Coinbase API interactions.
 -   **[QuantGeekDev/coincap-mcp](https://github.com/QuantGeekDev/coincap-mcp)** [![GitHub stars](https://img.shields.io/github/stars/QuantGeekDev/coincap-mcp?style=social)](https://github.com/QuantGeekDev/coincap-mcp): Provides real-time cryptocurrency market data from CoinCap.
 -   **[anjor/coinmarket-mcp-server](https://github.com/anjor/coinmarket-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/anjor/coinmarket-mcp-server?style=social)](https://github.com/anjor/coinmarket-mcp-server): Fetches cryptocurrency listings and quotes from the Coinmarket API.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Note that this list is continuously updating and improving. Please star this rep
 ### 💰 Finance & Fintech
 
 -   **[heurist-network/heurist-mesh-mcp-server](https://github.com/heurist-network/heurist-mesh-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/heurist-network/heurist-mesh-mcp-server?style=social)](https://github.com/heurist-network/heurist-mesh-mcp-server): Provides access to web3 AI agents for blockchain analysis and smart contract auditing.
+- [AgentServices](https://github.com/vbkotecha/aiservices-api) — Paid APIs for AI agents. Crypto prices, DeFi yields, indicators, dispute resolution. x402 on Base. MCP at api.aiservices.to/mcp.
 -   **[@base/base-mcp](https://github.com/base/base-mcp)** [![GitHub stars](https://img.shields.io/github/stars/base/base-mcp?style=social)](https://github.com/base/base-mcp): Integrates with Base Network for onchain tools and Coinbase API interactions.
 -   **[QuantGeekDev/coincap-mcp](https://github.com/QuantGeekDev/coincap-mcp)** [![GitHub stars](https://img.shields.io/github/stars/QuantGeekDev/coincap-mcp?style=social)](https://github.com/QuantGeekDev/coincap-mcp): Provides real-time cryptocurrency market data from CoinCap.
 -   **[anjor/coinmarket-mcp-server](https://github.com/anjor/coinmarket-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/anjor/coinmarket-mcp-server?style=social)](https://github.com/anjor/coinmarket-mcp-server): Fetches cryptocurrency listings and quotes from the Coinmarket API.


### PR DESCRIPTION
## AgentServices

Paid data APIs for AI agents with x402 on Base. 29 endpoints: crypto prices, DeFi yields, technical indicators, marketing intelligence, dispute resolution.

- Live: https://agentservices.to
- MCP: https://agentservices.to/mcp
- Repo: https://github.com/vbkotecha/aiservices-api

Added to Finance & Fintech section.