### PR TITLE
Add ghost-in-the-droid/android-agent — new Mobile Device Control section

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[modelcontextprotocol/server-puppeteer](https://github.com/modelcontextprotocol/servers/tree/main/src/puppeteer)** [![GitHub stars](https://img.shields.io/github/stars/modelcontextprotocol/servers?style=social)](https://github.com/modelcontextprotocol/servers): Automates web interactions and scraping using Puppeteer (part of the official servers collection).
 -   **[@kimtaeyoon83/mcp-server-youtube-transcript](https://github.com/kimtaeyoon83/mcp-server-youtube-transcript)** [![GitHub stars](https://img.shields.io/github/stars/kimtaeyoon83/mcp-server-youtube-transcript?style=social)](https://github.com/kimtaeyoon83/mcp-server-youtube-transcript): Extracts subtitles and transcripts from YouTube videos for AI processing.
 
+### 📱 Mobile Device Control
+
+-   **[ghost-in-the-droid/android-agent](https://github.com/ghost-in-the-droid/android-agent)** [![GitHub stars](https://img.shields.io/github/stars/ghost-in-the-droid/android-agent?style=social)](https://github.com/ghost-in-the-droid/android-agent): Give any LLM agent a real Android or iPhone as its body. 62 MCP tools: tap, swipe, screenshot, screen-tree reading, app launch, on-device inference (llama.cpp, MediaPipe, MLX), Docker+KVM emulator pools. Works with Claude Code, Cursor, LangChain, and any MCP client. `pip install ghost-in-the-droid`
+
 ### 🎨 Art & Culture
 
 -   **[burningion/video-editing-mcp](https://github.com/burningion/video-editing-mcp)** [![GitHub stars](https://img.shields.io/github/stars/burningion/video-editing-mcp?style=social)](https://github.com/burningion/video-editing-mcp): Enables AI-driven video editing, analysis, and search within a video collection.


### PR DESCRIPTION
## What is this?

Adds **Ghost in the Droid** under a new **📱 Mobile Device Control** section.

Ghost is an open-source MCP server that gives any LLM agent a real Android or iPhone as its body — 62 tools covering tap, swipe, screenshot, screen-tree reading, app launch, on-device inference (llama.cpp/MediaPipe/MLX), and Docker+KVM emulator pools.

- **Repo:** https://github.com/ghost-in-the-droid/android-agent/releases/tag/v1.3.0
- **PyPI:** `pip install ghost-in-the-droid`
- **Site:** https://ghostinthedroid.com
- **License:** MIT | **Language:** Python 🐍

Works with Claude Code, Cursor, LangChain, LlamaIndex, and any MCP client.