### PR TITLE
Add ChurnLens MCP server to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[OzorOwn/defi-mcp](https://github.com/OzorOwn/defi-mcp)** [![GitHub stars](https://img.shields.io/github/stars/OzorOwn/defi-mcp?style=social)](https://github.com/OzorOwn/defi-mcp): DeFi & crypto MCP server — token prices, wallet balances, gas prices, DEX swap quotes across 7 chains.
 -   **[8144225309/superscalar-mcp](https://github.com/8144225309/superscalar-mcp)** [![GitHub stars](https://img.shields.io/github/stars/8144225309/superscalar-mcp?style=social)](https://github.com/8144225309/superscalar-mcp): Bitcoin Lightning channel factory MCP server — query protocol architecture, estimate UTXO savings, and explore channel factory infrastructure.
 -   **[xpaysh/awesome-x402](https://github.com/xpaysh/awesome-x402)** [![GitHub stars](https://img.shields.io/github/stars/xpaysh/awesome-x402?style=social)](https://github.com/xpaysh/awesome-x402): A curated directory of x402 payment protocol MCP servers and tools for HTTP-native USDC payments on EVM chains.
+-   **[kindrat86/churnlens-mcp](https://github.com/kindrat86/churnlens-mcp)** [![GitHub stars](https://img.shields.io/github/stars/kindrat86/churnlens-mcp?style=social)](https://github.com/kindrat86/churnlens-mcp): Buyer-side SaaS due-diligence maths — net and gross revenue retention plus the spread that exposes churn masked by expansion, HHI revenue concentration, dormant "zombie" MRR, LTV:CAC with payback, and a composite health score. Keyless and hosted.
 
 ### 🎮 Gaming
 


### PR DESCRIPTION
Adds the ChurnLens MCP server to **Finance & Fintech**, following the existing entry format.

**Repo:** https://github.com/kindrat86/churnlens-mcp
**Live endpoint:** https://churnlens.site/api/mcp (streamable HTTP, MCP 2024-11-05)

Buyer-side SaaS due-diligence maths for acquirers and M&A analysts. Six tools: net and gross revenue retention (plus the NRR−GRR spread that exposes churn masked by expansion), HHI revenue concentration with whale detection, dormant "zombie" MRR, gross-margin-adjusted LTV:CAC with payback, and a composite 0–100 health score.

Keyless, no account, nothing stored. Returns `structuredContent` so agents receive typed numbers.

Scoring thresholds are labelled as bands rather than measured data, and the implementation is open source under MIT ([saas-metrics](https://github.com/kindrat86/saas-metrics) — zero dependencies, 27 tests), so any result reproduces independently.