### PR TITLE
Add current x402engine-mcp listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Note that this list is continuously updating and improving. Please star this rep
 
 ### 💰 Finance & Fintech
 
+-   **[agentc22/x402engine-mcp](https://github.com/agentc22/x402engine-mcp)** [![GitHub stars](https://img.shields.io/github/stars/agentc22/x402engine-mcp?style=social)](https://github.com/agentc22/x402engine-mcp): Connects agents to 108 x402 pay-per-call APIs: 72 LLMs plus image/video, web, code, crypto, audio, travel, and IPFS. Supports USDC on Base/Solana and USDm on MegaETH.
 -   **[heurist-network/heurist-mesh-mcp-server](https://github.com/heurist-network/heurist-mesh-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/heurist-network/heurist-mesh-mcp-server?style=social)](https://github.com/heurist-network/heurist-mesh-mcp-server): Provides access to web3 AI agents for blockchain analysis and smart contract auditing.
 -   **[@base/base-mcp](https://github.com/base/base-mcp)** [![GitHub stars](https://img.shields.io/github/stars/base/base-mcp?style=social)](https://github.com/base/base-mcp): Integrates with Base Network for onchain tools and Coinbase API interactions.
 -   **[QuantGeekDev/coincap-mcp](https://github.com/QuantGeekDev/coincap-mcp)** [![GitHub stars](https://img.shields.io/github/stars/QuantGeekDev/coincap-mcp?style=social)](https://github.com/QuantGeekDev/coincap-mcp): Provides real-time cryptocurrency market data from CoinCap.


### PR DESCRIPTION
Adds x402engine-mcp to Finance & Fintech from current `main`, replacing the conflicted submission in #45.

The description reflects the live 108-endpoint gateway, 72 LLMs, and Base/Solana/MegaETH payment support.
