### PR TITLE
Add Equibles (US stock market data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Note that this list is continuously updating and improving. Please star this rep
 
 ### 💰 Finance & Fintech
 
+-   **[daniel3303/stock-market-mcp-server](https://github.com/daniel3303/stock-market-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/daniel3303/stock-market-mcp-server?style=social)](https://github.com/daniel3303/stock-market-mcp-server): US stock market data — live stock and options prices, congressional trades, insider transactions, SEC filings full-text search, XBRL fundamentals, 13F holdings, and earnings-call transcripts. 90+ tools.
 -   **[heurist-network/heurist-mesh-mcp-server](https://github.com/heurist-network/heurist-mesh-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/heurist-network/heurist-mesh-mcp-server?style=social)](https://github.com/heurist-network/heurist-mesh-mcp-server): Provides access to web3 AI agents for blockchain analysis and smart contract auditing.
 -   **[@base/base-mcp](https://github.com/base/base-mcp)** [![GitHub stars](https://img.shields.io/github/stars/base/base-mcp?style=social)](https://github.com/base/base-mcp): Integrates with Base Network for onchain tools and Coinbase API interactions.
 -   **[QuantGeekDev/coincap-mcp](https://github.com/QuantGeekDev/coincap-mcp)** [![GitHub stars](https://img.shields.io/github/stars/QuantGeekDev/coincap-mcp?style=social)](https://github.com/QuantGeekDev/coincap-mcp): Provides real-time cryptocurrency market data from CoinCap.


### PR DESCRIPTION
Adds Equibles under Finance & Fintech.

US stock market data over MCP: live stock and options prices, congressional trades, insider transactions, SEC filings full-text search, XBRL fundamentals, 13F institutional holdings, earnings-call transcripts, short interest, and FRED macro series. 90+ tools.

Hosted at `https://mcp.equibles.com/mcp` (free API key or OAuth); also self-hostable.