### PR TITLE
Add Trends MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[c5huracan/meyhem](https://github.com/c5huracan/meyhem)** [![GitHub stars](https://img.shields.io/github/stars/c5huracan/meyhem?style=social)](https://github.com/c5huracan/meyhem): Agent-native search that blends multiple engines, dedupes results, and ranks by task-completion outcomes. No API key required.
 -   **[shopsavvy/shopsavvy-mcp-server](https://github.com/shopsavvy/shopsavvy-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/shopsavvy/shopsavvy-mcp-server?style=social)](https://github.com/shopsavvy/shopsavvy-mcp-server): Complete product and pricing data solution for AI assistants. Search for products by barcode/ASIN/URL, access detailed product metadata, access comprehensive pricing data from thousands of retailers, view and track price history, and more. Published as `@shopsavvy/mcp-server`.
 -   **[Pattyboi101/indiestack](https://github.com/Pattyboi101/indiestack)** [![GitHub stars](https://img.shields.io/github/stars/Pattyboi101/indiestack?style=social)](https://github.com/Pattyboi101/indiestack): Search 130+ indie SaaS tools from your AI coding assistant. Install via `pip install indiestack`.
+- [Trends MCP](https://github.com/trendsmcp-ai/Trends-MCP) - Live trend data across 25+ platforms via MCP and REST API.
 
 ### 🛠️ Utilities
 


### PR DESCRIPTION
Adds a listing for [Trends MCP](https://github.com/trendsmcp-ai/Trends-MCP) (https://trendsmcp.ai).

Live trend data MCP server and REST API across 25+ platforms (Google Search, YouTube, TikTok, Reddit, Amazon, Wikipedia, news sentiment, app downloads, npm, Steam, and more).

Public product links only. No secrets or credentials included.