### PR TITLE
Add Zephex hosted MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[MladenSU/cli-mcp-server](https://github.com/MladenSU/cli-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/MladenSU/cli-mcp-server?style=social)](https://github.com/MladenSU/cli-mcp-server): Offers a command-line interface with configurable security policies.
 -   **[tumf/mcp-shell-server](https://github.com/tumf/mcp-shell-server)** [![GitHub stars](https://img.shields.io/github/stars/tumf/mcp-shell-server?style=social)](https://github.com/tumf/mcp-shell-server): Securely executes shell commands through the Model Context Protocol.
 -   **[amol21p/mcp-interactive-terminal](https://github.com/amol21p/mcp-interactive-terminal)** [![GitHub stars](https://img.shields.io/github/stars/amol21p/mcp-interactive-terminal?style=social)](https://github.com/amol21p/mcp-interactive-terminal): Real interactive terminal sessions for REPLs, SSH, database clients, and any interactive CLI — with clean text output, smart completion detection, and multi-layer security.
+-   **[zephexMCP/zephex-MCPs](https://github.com/zephexMCP/zephex-MCPs)** [![GitHub stars](https://img.shields.io/github/stars/zephexMCP/zephex-MCPs?style=social)](https://github.com/zephexMCP/zephex-MCPs): Hosted MCP for coding agents — project context, find_code, package safety, Test Pulse. Cursor/Claude/Codex + CLI. https://zephex.dev/mcp
 
 ### 💬 Communication
 


### PR DESCRIPTION
Adds a short Zephex listing.

**What:** Hosted MCP that grounds AI agents in your live repo (context, search, package safety, tests).
**Works with:** Cursor, Claude Code, Codex, OpenCode, VS Code — plus CLI & web terminal.
**Links:** https://zephex.dev/mcp · https://github.com/zephexMCP/zephex-MCPs
**Note:** Complements Context7 (library docs) and GitHub MCP (PRs) — not a docs-only server.