### PR TITLE
Add Hexis to Knowledge and Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Note that this list is continuously updating and improving. Please star this rep
 
 ### 🧠 Knowledge & Memory
 
+-   **[Bevel-Software/Hexis](https://github.com/Bevel-Software/Hexis)** [![GitHub stars](https://img.shields.io/github/stars/Bevel-Software/Hexis?style=social)](https://github.com/Bevel-Software/Hexis): Git-backed platform for skills, tools, and context for AI agents, exposed through a remote OAuth MCP server.
 -   **[modelcontextprotocol/server-memory](https://github.com/modelcontextprotocol/servers/tree/main/src/memory)** [![GitHub stars](https://img.shields.io/github/stars/modelcontextprotocol/servers?style=social)](https://github.com/modelcontextprotocol/servers): Provides a knowledge graph-based persistent memory system (part of the official servers collection).
 -   **[CheMiguel23/MemoryMesh](https://github.com/CheMiguel23/MemoryMesh)** [![GitHub stars](https://img.shields.io/github/stars/CheMiguel23/MemoryMesh?style=social)](https://github.com/CheMiguel23/MemoryMesh): Provides enhanced graph-based memory focused on AI role-play.
 -   **[topoteretes/cognee-mcp](https://github.com/topoteretes/cognee/tree/dev/cognee-mcp)** [![GitHub stars](https://img.shields.io/github/stars/topoteretes/cognee?style=social)](https://github.com/topoteretes/cognee): Manages AI memory using graph/vector stores, with ingestion from 30+ data sources (part of Cognee project).


### PR DESCRIPTION
Adds Hexis to Knowledge and Memory. It is a Git-backed platform for skills, tools, and context for AI agents, exposed through a remote OAuth MCP server.

Disclosure: I work on Hexis.