### PR TITLE
Add stipend-sh/stipend to Finance & Fintech

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[OzorOwn/defi-mcp](https://github.com/OzorOwn/defi-mcp)** [![GitHub stars](https://img.shields.io/github/stars/OzorOwn/defi-mcp?style=social)](https://github.com/OzorOwn/defi-mcp): DeFi & crypto MCP server — token prices, wallet balances, gas prices, DEX swap quotes across 7 chains.
 -   **[8144225309/superscalar-mcp](https://github.com/8144225309/superscalar-mcp)** [![GitHub stars](https://img.shields.io/github/stars/8144225309/superscalar-mcp?style=social)](https://github.com/8144225309/superscalar-mcp): Bitcoin Lightning channel factory MCP server — query protocol architecture, estimate UTXO savings, and explore channel factory infrastructure.
 -   **[xpaysh/awesome-x402](https://github.com/xpaysh/awesome-x402)** [![GitHub stars](https://img.shields.io/github/stars/xpaysh/awesome-x402?style=social)](https://github.com/xpaysh/awesome-x402): A curated directory of x402 payment protocol MCP servers and tools for HTTP-native USDC payments on EVM chains.
+-   **[stipend-sh/stipend](https://github.com/stipend-sh/stipend)** [![GitHub stars](https://img.shields.io/github/stars/stipend-sh/stipend?style=social)](https://github.com/stipend-sh/stipend): Non-custodial USDC wallet on Base for agents — per-transaction, per-day and per-counterparty spending limits plus a destination allowlist enforced in code rather than in a prompt.
 
 ### 🎮 Gaming
 


### PR DESCRIPTION
One entry, appended to **💰 Finance & Fintech**, in the same `owner/repo` + stars-badge format as the surrounding lines.

[stipend](https://github.com/stipend-sh/stipend) is a non-custodial USDC wallet on Base that an AI agent installs by itself. Per-transaction, per-day and per-counterparty caps plus a destination allowlist are enforced in code between the agent's decision and the signature, so no instruction in the context window can raise them.

MCP server: `stipend mcp`, JSON-RPC over stdio, 7 tools — `stipend_address`, `stipend_balance`, `stipend_check`, `stipend_pay`, `stipend_earnings`, `stipend_report`, `stipend_recover`. Nothing listens on a port.

Python, Apache-2.0, not audited.
