### PR TITLE
Add Lians local-first memory server

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[graphlit/graphlit-mcp-server](https://github.com/graphlit/graphlit-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/graphlit/graphlit-mcp-server?style=social)](https://github.com/graphlit/graphlit-mcp-server): Ingests data from various sources into a Graphlit project for searching and retrieval.
 -   **[CanopyHQ/phloem](https://github.com/CanopyHQ/phloem)** [![GitHub stars](https://img.shields.io/github/stars/CanopyHQ/phloem?style=social)](https://github.com/CanopyHQ/phloem): Local-first AI memory with causal graphs, citation verification, and zero network connections.
 -   **[omega-memory/core](https://github.com/omega-memory/core)** [![GitHub stars](https://img.shields.io/github/stars/omega-memory/core?style=social)](https://github.com/omega-memory/core): Persistent memory for AI coding agents with semantic search, auto-capture, intelligent forgetting, and cross-session learning. #1 on LongMemEval (95.4%). Local-first with zero cloud dependency.
+-   **[Lians-ai/Lians](https://github.com/Lians-ai/Lians)** [![GitHub stars](https://img.shields.io/github/stars/Lians-ai/Lians?style=social)](https://github.com/Lians-ai/Lians): Runs local-first agent memory with SQLite, cross-session recall, and point-in-time history through MCP.
 
 ### 🗺️ Location Services
 


### PR DESCRIPTION
Adds Lians to the existing Knowledge & Memory section. The entry links directly to the Apache-2.0 repository and describes the released local SQLite, MCP, cross-session recall, and point-in-time history behavior.

I searched the README and pull requests for an existing Lians entry before submitting.

Disclosure: I am a Lians maintainer. This contribution was prepared with AI assistance and reviewed before submission.