### PR TITLE
Add Palisade DMARC Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[arpitbatra123/mcp-googletasks](https://github.com/arpitbatra123/mcp-googletasks)** [![GitHub stars](https://img.shields.io/github/stars/arpitbatra123/mcp-googletasks?style=social)](https://github.com/arpitbatra123/mcp-googletasks): Interfaces with the Google Tasks API for task management.
 -   **[Eclipse-XV/twitch-mcp](https://github.com/Eclipse-XV/twitch-mcp)** [![GitHub stars](https://img.shields.io/github/stars/Eclipse-XV/twitch-mcp?style=social)](https://github.com/Eclipse-XV/twitch-mcp): Allows Twitch streamers to automate channel point predictions, trigger stream events, and extend interactive chat functionality.
 -   **[@taskade/mcp](https://github.com/taskade/mcp)** [![GitHub stars](https://img.shields.io/github/stars/taskade/mcp?style=social)](https://github.com/taskade/mcp): Official Taskade MCP server with 50+ tools for managing workspaces, projects, tasks, custom AI agents, and workflow automations. Includes OpenAPI-to-MCP codegen.
+-   **[palisadeemail/palisade-mcp](https://github.com/palisadeemail/palisade-mcp)** [![GitHub stars](https://img.shields.io/github/stars/palisadeemail/palisade-mcp?style=social)](https://github.com/palisadeemail/palisade-mcp): Official Palisade MCP server for AI-powered DMARC, SPF, DKIM, BIMI, MTA-STS, DNS, domain verification, and email-authentication remediation management.
 
 ### 👤 Customer Data Platforms
 


### PR DESCRIPTION
## Summary

Adds Palisade DMARC Agent to the Communication section.

Palisade gives AI agents access to DMARC, SPF, DKIM, BIMI, MTA-STS, DNS, domain verification, and remediation workflows.

## Validation

- `git diff --check`