### PR TITLE
Add @1claw/mcp (secret vault for AI agents) to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Note that this list is continuously updating and improving. Please star this rep
 
 ### 💻 Developer Tools
 
+-   **[@1claw/mcp](https://github.com/1clawAI/1claw-mcp)** [![GitHub stars](https://img.shields.io/github/stars/1clawAI/1claw-mcp?style=social)](https://github.com/1clawAI/1claw-mcp): HSM-backed secret vault for AI agents. Fetches API keys and tokens at call time with scoped, short-lived, revocable access so raw secrets never touch the model context, environment, or logs. Also does keyless multi-chain signing and a no-account local prompt-injection inspector.
+
 -   **[21st-dev/Magic-MCP](https://github.com/21st-dev/magic-mcp)** [![GitHub stars](https://img.shields.io/github/stars/21st-dev/magic-mcp?style=social)](https://github.com/21st-dev/magic-mcp): Generates UI components based on 21st.dev design principles.
 -   **[cocoindex-io/cocoindex-code](https://github.com/cocoindex-io/cocoindex-code)** [![GitHub stars](https://img.shields.io/github/stars/cocoindex-io/cocoindex-code?style=social)](https://github.com/cocoindex-io/cocoindex-code): A super light-weight embedded MCP server for coding agents. Uses tree-sitter for code search and indexing, saves 70% tokens and improves speed.
 -   **[Comet-ML/Opik-MCP](https://github.com/comet-ml/opik-mcp)** [![GitHub stars](https://img.shields.io/github/stars/comet-ml/opik-mcp?style=social)](https://github.com/comet-ml/opik-mcp): Enables querying of LLM observability data captured by Opik.


### PR DESCRIPTION
Adds [@1claw/mcp](https://github.com/1clawAI/1claw-mcp), an MCP server that gives AI agents secure, just-in-time access to secrets from an HSM-backed vault: scoped, short-lived, revocable tokens so raw keys never touch the model context, env, or logs. Also does keyless multi-chain signing and a no-account local prompt-injection inspector (`ONECLAW_LOCAL_ONLY=true npx -y @1claw/mcp`). npm: `@1claw/mcp`, in the official MCP registry. Placed under Developer Tools; happy to move it if you'd prefer a different category.