### PR TITLE
Add SandBase Harness MCP bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[MladenSU/cli-mcp-server](https://github.com/MladenSU/cli-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/MladenSU/cli-mcp-server?style=social)](https://github.com/MladenSU/cli-mcp-server): Offers a command-line interface with configurable security policies.
 -   **[tumf/mcp-shell-server](https://github.com/tumf/mcp-shell-server)** [![GitHub stars](https://img.shields.io/github/stars/tumf/mcp-shell-server?style=social)](https://github.com/tumf/mcp-shell-server): Securely executes shell commands through the Model Context Protocol.
 -   **[amol21p/mcp-interactive-terminal](https://github.com/amol21p/mcp-interactive-terminal)** [![GitHub stars](https://img.shields.io/github/stars/amol21p/mcp-interactive-terminal?style=social)](https://github.com/amol21p/mcp-interactive-terminal): Real interactive terminal sessions for REPLs, SSH, database clients, and any interactive CLI — with clean text output, smart completion detection, and multi-layer security.
+-   **[sandbaseai/sandbase-harness](https://github.com/sandbaseai/sandbase-harness)** [![GitHub stars](https://img.shields.io/github/stars/sandbaseai/sandbase-harness?style=social)](https://github.com/sandbaseai/sandbase-harness): Local-first TypeScript agent runtime with a stdio MCP bridge, persistent sessions, sandboxed tools, memory, credentials, audit logs, and execution replay.
 
 ### 💬 Communication
 


### PR DESCRIPTION
## Summary
- add SandBase Harness to the Command Line MCP server list
- describe the official stdio bridge and its connected agent runtime capabilities
- include the repository and live GitHub star badge

The entry follows the existing concise-list format and is based on the official SandBase Harness documentation.