### PR TITLE
Add SandBase Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Note that this list is continuously updating and improving. Please star this rep
 ### 🤖 AI Agents & Frameworks
 
 -   **[MervinPraison/praisonai-mcp](https://github.com/MervinPraison/praisonai-mcp)** [![GitHub stars](https://img.shields.io/github/stars/MervinPraison/praisonai-mcp?style=social)](https://github.com/MervinPraison/praisonai-mcp): AI Agent framework with built-in MCP tools for search, memory, workflows, code execution, and file operations.
+-   **[sandbaseai/sandbase-harness](https://github.com/sandbaseai/sandbase-harness)** [![GitHub stars](https://img.shields.io/github/stars/sandbaseai/sandbase-harness?style=social)](https://github.com/sandbaseai/sandbase-harness): Local-first, self-hosted AI-agent runtime and MCP bridge with persistent sessions, approvals, credentials, audit/replay, and selectable execution backends.
 
 ### ☁️ Cloud Platforms
 


### PR DESCRIPTION
## Summary

- add SandBase Harness to the AI Agents & Frameworks section
- link the official repository and current public project description
- include the repository's GitHub star badge consistent with the list format

Disclosure: I maintain/contribute to SandBase Harness and am submitting this entry on behalf of the project. Isolation depends on the selected backend and deployment configuration; this directory entry is not an endorsement or security certification.
