### PR TITLE
Add local-gpu-imagegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Note that this list is continuously updating and improving. Please star this rep
 
 ### 🎨 Art & Culture
 
+-   **[ChevalGrand520/local-gpu-imagegen](https://github.com/ChevalGrand520/local-gpu-imagegen)** [![GitHub stars](https://img.shields.io/github/stars/ChevalGrand520/local-gpu-imagegen?style=social)](https://github.com/ChevalGrand520/local-gpu-imagegen): Confirmation-gated local NVIDIA GPU image generation for AI agents via your existing ComfyUI install, with SHA-256 model identity, explicit license approval, and no silent model downloads. Windows x64 NVIDIA. `uvx --from local-gpu-imagegen==0.9.1 local-gpu-imagegen serve`.
 -   **[8enSmith/mcp-open-library](https://github.com/8enSmith/mcp-open-library)** [![GitHub stars](https://img.shields.io/github/stars/8enSmith/mcp-open-library?style=social)](https://github.com/8enSmith/mcp-open-library): Connects to the Internet Archive's Open Library API to search book and author information.
 
 -   **[burningion/video-editing-mcp](https://github.com/burningion/video-editing-mcp)** [![GitHub stars](https://img.shields.io/github/stars/burningion/video-editing-mcp?style=social)](https://github.com/burningion/video-editing-mcp): Enables AI-driven video editing, analysis, and search within a video collection.


### PR DESCRIPTION
Adds `ChevalGrand520/local-gpu-imagegen` to the Art & Culture category.

The server gives MCP clients confirmation-gated access to local NVIDIA GPU image generation through an existing ComfyUI installation. Windows x64 NVIDIA only. 17 tools over stdio, installed via `uvx --from local-gpu-imagegen==0.9.1 local-gpu-imagegen serve`. MIT licensed.

Verification: public repo (https://github.com/ChevalGrand520/local-gpu-imagegen), PyPI 0.9.1 (https://pypi.org/project/local-gpu-imagegen/), MCP Registry `io.github.ChevalGrand520/local-gpu-imagegen`.