### PR TITLE
Add Aperture Wallet Knowledge server

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Note that this list is continuously updating and improving. Please star this rep
 
 ### 💰 Finance & Fintech
 
+-   **[devdasx/aperture](https://github.com/devdasx/aperture)** [![GitHub stars](https://img.shields.io/github/stars/devdasx/aperture?style=social)](https://github.com/devdasx/aperture): Official public, read-only Aperture Wallet knowledge server for product facts, self-custody security boundaries, 25 production mainnets, documented features, App Store releases, screen semantics, and Journal articles. Streamable HTTP at `https://aperturex.io/mcp/`; no authentication and no wallet, credential, signing, or transaction access.
 -   **[heurist-network/heurist-mesh-mcp-server](https://github.com/heurist-network/heurist-mesh-mcp-server)** [![GitHub stars](https://img.shields.io/github/stars/heurist-network/heurist-mesh-mcp-server?style=social)](https://github.com/heurist-network/heurist-mesh-mcp-server): Provides access to web3 AI agents for blockchain analysis and smart contract auditing.
 -   **[@base/base-mcp](https://github.com/base/base-mcp)** [![GitHub stars](https://img.shields.io/github/stars/base/base-mcp?style=social)](https://github.com/base/base-mcp): Integrates with Base Network for onchain tools and Coinbase API interactions.
 -   **[QuantGeekDev/coincap-mcp](https://github.com/QuantGeekDev/coincap-mcp)** [![GitHub stars](https://img.shields.io/github/stars/QuantGeekDev/coincap-mcp?style=social)](https://github.com/QuantGeekDev/coincap-mcp): Provides real-time cryptocurrency market data from CoinCap.


### PR DESCRIPTION
## Summary

Adds the official Aperture Wallet Knowledge server to **Finance & Fintech**.

## Verified details

- Source and maintainer: https://github.com/devdasx/aperture
- Production endpoint: `https://aperturex.io/mcp/`
- Transport: Streamable HTTP
- Authentication: none
- Tools: 12, all read-only
- Official MCP Registry id: `io.aperturex/aperture-wallet-knowledge` v1.0.0
- Verified live: 2026-09-02

The description makes the security boundary explicit: this server exposes only public product and documentation knowledge. It cannot access a wallet, balances, credentials, signing, authorization, broadcast, or transactions.

All links in the new entry return HTTP 200, and `git diff --check` passes.
