### PR TITLE
Add meelu-analytics-mcp to Data Science Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Note that this list is continuously updating and improving. Please star this rep
 
 -   **[ChronulusAI/chronulus-mcp](https://github.com/ChronulusAI/chronulus-mcp)** [![GitHub stars](https://img.shields.io/github/stars/ChronulusAI/chronulus-mcp?style=social)](https://github.com/ChronulusAI/chronulus-mcp): Uses Chronulus AI for forecasting and predictions.
 -   **[@reading-plus-ai/mcp-server-data-exploration](https://github.com/reading-plus-ai/mcp-server-data-exploration)** [![GitHub stars](https://img.shields.io/github/stars/reading-plus-ai/mcp-server-data-exploration?style=social)](https://github.com/reading-plus-ai/mcp-server-data-exploration): Enables autonomous data exploration on `.csv`-based datasets.
+-   **[@shubham303/meelu-analytics-mcp](https://github.com/shubham303/meelu-analytics-mcp)** [![GitHub stars](https://img.shields.io/github/stars/shubham303/meelu-analytics-mcp?style=social)](https://github.com/shubham303/meelu-analytics-mcp): Deterministic analysis of `.csv` datasets — 45 tools for profiling, statistical testing, ML, forecasting and causal inference; picks the right test from the data and rates its own confidence.
 
 ### 📂 File Systems
 


### PR DESCRIPTION
Adds [shubham303/meelu-analytics-mcp](https://github.com/shubham303/meelu-analytics-mcp) to **Data Science Tools**.

A local MCP server for statistical analysis of CSV data. 45 tools covering profiling, association testing, feature engineering, clustering, supervised ML with held-out scoring, time series, causal inference and customer analytics.

What makes it different from a general data-exploration server: method selection is deterministic rather than left to the model. It checks normality, variance and expected cell counts, routes to the appropriate test (Pearson/Spearman, Welch/Mann-Whitney, ANOVA/Kruskal-Wallis, chi-square/Fisher), and records which it chose and why. Every result carries a confidence level, and it declines to answer when the data cannot support the question. Runs locally on DuckDB, MIT licensed.

- Single line added, matching the existing entry format (bold linked name, star badge, concise description)
- Placed in the Data Science Tools category alongside the other CSV-analysis servers
- No other changes