### PR TITLE
Add Speak AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Note that this list is continuously updating and improving. Please star this rep
 -   **[@bifrost-mcp/rippling-mcp](https://github.com/bifrost-mcp/rippling-mcp)** [![GitHub stars](https://img.shields.io/github/stars/bifrost-mcp/rippling-mcp?style=social)](https://github.com/bifrost-mcp/rippling-mcp): Integrates with Rippling HR, IT, and Finance platform for employee and company management.
 -   **[synapbus/synapbus](https://github.com/synapbus/synapbus)** [![GitHub stars](https://img.shields.io/github/stars/synapbus/synapbus?style=social)](https://github.com/synapbus/synapbus): MCP-native agent-to-agent messaging hub with channels, DMs, semantic search, task auction, and web UI.
 -   **[TourAround/LystBot](https://github.com/TourAround/LystBot)** [![GitHub stars](https://img.shields.io/github/stars/TourAround/LystBot?style=social)](https://github.com/TourAround/LystBot): AI-powered list management for grocery lists, to-dos, and shared packing lists.
+-   **[speakai/speakai-mcp](https://github.com/speakai/speakai-mcp)** [![GitHub stars](https://img.shields.io/github/stars/speakai/speakai-mcp?style=social)](https://github.com/speakai/speakai-mcp): Official Speak AI server: transcribe, search, and analyze audio/video (100+ languages, speaker labels, call scoring on custom rubrics). npm @speakai/mcp-server, MIT.
 
 ### 👤 Customer Data Platforms
 


### PR DESCRIPTION
- Speak AI is the official MCP server for the Speak AI transcription and call-analysis platform: transcribe, search, and analyze audio/video (100+ languages, speaker labels, call scoring on custom rubrics).
- Officially maintained: repo https://github.com/speakai/speakai-mcp, npm package @speakai/mcp-server, MIT license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECfv85U3ZpQrHapVskBN8z