### PR TITLE
Add ParlayAPI to Fitness & Sports

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Note that this list is continuously updating and improving. Please star this rep
 
 ### 🏃 Fitness & Sports
 
+-   **[JacobiusMakes/parlay-api-mcp](https://github.com/JacobiusMakes/parlay-api-mcp)** [![GitHub stars](https://img.shields.io/github/stars/JacobiusMakes/parlay-api-mcp?style=social)](https://github.com/JacobiusMakes/parlay-api-mcp): Connects MCP clients to ParlayAPI for sports odds, player props, public event discovery, and account usage. Account data tools use each user's own API key and account allowances.
 -   **[JamsusMaximus/trainingpeaks-mcp](https://github.com/JamsusMaximus/trainingpeaks-mcp)** [![GitHub stars](https://img.shields.io/github/stars/JamsusMaximus/trainingpeaks-mcp?style=social)](https://github.com/JamsusMaximus/trainingpeaks-mcp): Accesses TrainingPeaks fitness metrics, workout history, and personal records for endurance athletes.
 
 ### 🎮 Gaming


### PR DESCRIPTION
Adds ParlayAPI to Fitness & Sports using the existing entry format. I maintain the linked Python MCP server, which provides sports odds, player props, public event discovery and account usage. Account data tools require each user's own key and allowances.

Checked current entries and issues/PRs for duplicates; `git diff --check` passes. The published launch command passed MCP initialization and 22-tool discovery without account calls. No native-client attestation or data redistribution rights are claimed.
